### PR TITLE
chore: Pin Github Actions to Commit Hashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,16 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        sdk: [stable, beta]
 
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
-      - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d # v1.3
+
+      - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1.7.1
+        with:
+          sdk: ${{ matrix.sdk }}
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Run tests and generate coverage report
         run: ./tool/generate_code_coverage.sh
 
+      - name: Setup LCOV
+        uses: hrishikesh-kadam/setup-lcov@6c1aa0cc9e1c02f9f58f01ac599f1064ccc83470 # v1.1
+
       - name: Report code coverage
         uses: zgosalvez/github-actions-report-lcov@eda775f552bfb2bffbdedea26f19dfb8c24a1648 # v4.1.26
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,4 +75,4 @@ jobs:
           dart pub global activate pana
 
       - name: Verify pub score
-        run: ./tool/verify_pub_score.sh
+        run: ./tool/verify_pub_score.sh 150

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           coverage-files: coverage/lcov.info
           minimum-coverage: 90
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-name: code-coverage-report
+          artifact-name: code-coverage-report-${{ matrix.sdk }}
 
   pana:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.0.2
-      - uses: dart-lang/setup-dart@v1.3
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+      - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d # v1.3
 
       - name: Install dependencies
         run: dart pub get
@@ -32,13 +32,13 @@ jobs:
         run: dart format --output=none --set-exit-if-changed .
 
       - name: Analyze project source
-        uses: invertase/github-action-dart-analyzer@v1
+        uses: invertase/github-action-dart-analyzer@cdd8652b05bf7ed08ffce30f425436780f869f13 # v1
 
       - name: Run tests and generate coverage report
         run: ./tool/generate_code_coverage.sh
 
       - name: Report code coverage
-        uses: zgosalvez/github-actions-report-lcov@v1.5.0
+        uses: zgosalvez/github-actions-report-lcov@8b72ce00008730f66e6d211e54359243012b9606 # v1.5.0
         with:
           coverage-files: coverage/lcov.info
           minimum-coverage: 90
@@ -49,8 +49,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.0.2
-      - uses: dart-lang/setup-dart@v1.3
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+      - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d # v1.3
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,15 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         sdk: [stable, beta]
 
@@ -62,6 +63,6 @@ jobs:
         run: |
           dart pub get
           dart pub global activate pana
-      
+
       - name: Verify pub score
         run: ./tool/verify_pub_score.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
 
-        - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1.7.1
+      - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1.7.1
         with:
           sdk: ${{ matrix.sdk }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,17 @@ jobs:
 
   pana:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sdk: [stable, beta]
 
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
-      - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d # v1.3
+
+        - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1.7.1
+        with:
+          sdk: ${{ matrix.sdk }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         run: ./tool/generate_code_coverage.sh
 
       - name: Report code coverage
-        uses: zgosalvez/github-actions-report-lcov@8b72ce00008730f66e6d211e54359243012b9606 # v1.5.0
+        uses: zgosalvez/github-actions-report-lcov@eda775f552bfb2bffbdedea26f19dfb8c24a1648 # v4.1.26
         with:
           coverage-files: coverage/lcov.info
           minimum-coverage: 90

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,8 @@
 include: package:lints/recommended.yaml
 
+formatter:
+  page_width: 120
+
 linter:
   rules:
     - package_api_docs

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,7 +1,7 @@
 include: package:lints/recommended.yaml
 
 formatter:
-  page_width: 120
+  page_width: 80
 
 linter:
   rules:

--- a/bin/report_to_junit.dart
+++ b/bin/report_to_junit.dart
@@ -11,10 +11,7 @@ Future<void> main(List<String> args) async {
   final arguments = _parseArguments(args);
   final lines = LineSplitter().bind(utf8.decoder.bind(arguments.source));
   try {
-    final report = await _createReport(
-      arguments: arguments,
-      lines: lines,
-    );
+    final report = await _createReport(arguments: arguments, lines: lines);
     final xml = TestJsonToJunit(
       base: arguments.base,
       package: arguments.package,
@@ -45,39 +42,40 @@ Future<Report> _createReport({
 }
 
 _Arguments _parseArguments(List<String> args) {
-  final parser = ArgParser()
-    ..addOption(
-      'input',
-      abbr: 'i',
-      help: """
+  final parser =
+      ArgParser()
+        ..addOption(
+          'input',
+          abbr: 'i',
+          help: """
 the path to the 'json' file containing the output of 'pub run test'.
 if missing, <stdin> will be used""",
-    )
-    ..addOption(
-      'output',
-      abbr: 'o',
-      help: '''
+        )
+        ..addOption(
+          'output',
+          abbr: 'o',
+          help: '''
 the path of the to be generated junit xml file.
 if missing, <stdout> will be used''',
-    )
-    ..addOption(
-      'base',
-      abbr: 'b',
-      help: """
+        )
+        ..addOption(
+          'base',
+          abbr: 'b',
+          help: """
 the part to strip from the 'path' elements in the source.
 defaults to current working directory""",
-      defaultsTo: Directory.current.path,
-    )
-    ..addOption(
-      'package',
-      abbr: 'p',
-      help: "the part to prepend to the 'path' elements in the source",
-      defaultsTo: '',
-    )
-    ..addOption(
-      'timestamp',
-      abbr: 't',
-      help: """
+          defaultsTo: Directory.current.path,
+        )
+        ..addOption(
+          'package',
+          abbr: 'p',
+          help: "the part to prepend to the 'path' elements in the source",
+          defaultsTo: '',
+        )
+        ..addOption(
+          'timestamp',
+          abbr: 't',
+          help: """
 the timestamp to be used in the report
 - 'now' will use the current date/time
 - 'none' will suppress timestamps altogether
@@ -85,14 +83,14 @@ the timestamp to be used in the report
 - if no value is provided
     - if '--input' is specified the file modification date/time is used
     - otherwise the current date/time is used""",
-    )
-    ..addFlag(
-      'help',
-      abbr: 'h',
-      help: 'display this help text',
-      negatable: false,
-      defaultsTo: false,
-    );
+        )
+        ..addFlag(
+          'help',
+          abbr: 'h',
+          help: 'display this help text',
+          negatable: false,
+          defaultsTo: false,
+        );
 
   try {
     final result = parser.parse(args);
@@ -126,10 +124,7 @@ the timestamp to be used in the report
   }
 }
 
-DateTime? _processTimestamp({
-  String? timestamp,
-  required _Source source,
-}) {
+DateTime? _processTimestamp({String? timestamp, required _Source source}) {
   if (timestamp == null) {
     return source.timestamp;
   }
@@ -147,10 +142,7 @@ DateTime? _processTimestamp({
 
 _Source _processInput(String? input) {
   if (input == null) {
-    return _Source(
-      source: stdin,
-      timestamp: DateTime.now(),
-    );
+    return _Source(source: stdin, timestamp: DateTime.now());
   }
   final file = File(input);
   if (!file.existsSync()) {
@@ -158,10 +150,7 @@ _Source _processInput(String? input) {
     exit(1);
   }
   try {
-    return _Source(
-      source: file.openRead(),
-      timestamp: file.lastModifiedSync(),
-    );
+    return _Source(source: file.openRead(), timestamp: file.lastModifiedSync());
   } catch (e) {
     stderr.writeln("Cannot read file '$input' (${file.absolute.path})");
     exit(1);
@@ -199,8 +188,5 @@ class _Source {
   final Stream<List<int>> source;
   final DateTime timestamp;
 
-  _Source({
-    required this.source,
-    required this.timestamp,
-  });
+  _Source({required this.source, required this.timestamp});
 }

--- a/lib/src/junit_xml/test_json_to_junit.dart
+++ b/lib/src/junit_xml/test_json_to_junit.dart
@@ -16,10 +16,7 @@ class TestJsonToJunit {
   final String package;
 
   /// Constructs a TestJsonToJunit from the base string to strip out of paths and the package string to prepend to paths.
-  const TestJsonToJunit({
-    required this.base,
-    required this.package,
-  });
+  const TestJsonToJunit({required this.base, required this.package});
 
   /// Generates a string junit xml report from a [Report]
   String toXml(Report report) {
@@ -29,11 +26,7 @@ class TestJsonToJunit {
       'testsuites',
       nest: () {
         for (final suite in report.suites) {
-          _buildSuite(
-            builder: builder,
-            suite: suite,
-            timestamp: report.timestamp,
-          );
+          _buildSuite(builder: builder, suite: suite, timestamp: report.timestamp);
         }
       },
     );
@@ -43,26 +36,16 @@ class TestJsonToJunit {
       pretty: true,
       preserveWhitespace: (XmlNode node) {
         if (node is! XmlElement) return false;
-        return [
-          'system-out',
-          'error',
-          'failure',
-        ].contains(node.name.local);
+        return ['system-out', 'error', 'failure'].contains(node.name.local);
       },
     );
   }
 
-  void _buildSuite({
-    required XmlBuilder builder,
-    required Suite suite,
-    DateTime? timestamp,
-  }) {
+  void _buildSuite({required XmlBuilder builder, required Suite suite, DateTime? timestamp}) {
     final className = _convertPathToClassName(suite.path);
     final attributes = <String, String>{
-      'errors':
-          '${suite.problems.where((t) => !t.problems.every((p) => p.isFailure)).length}',
-      'failures':
-          '${suite.problems.where((t) => t.problems.every((p) => p.isFailure)).length}',
+      'errors': '${suite.problems.where((t) => !t.problems.every((p) => p.isFailure)).length}',
+      'failures': '${suite.problems.where((t) => t.problems.every((p) => p.isFailure)).length}',
       'tests': '${suite.tests.length}',
       'skipped': '${suite.skipped.length}',
       'name': className,
@@ -72,123 +55,69 @@ class TestJsonToJunit {
       'testsuite',
       attributes: attributes,
       nest: () {
-        _buildProperties(
-          builder: builder,
-          platform: suite.platform,
-        );
+        _buildProperties(builder: builder, platform: suite.platform);
         final prints = <String>[];
         for (final test in suite.allTests) {
           if (test.hidden && test.problems.isEmpty) {
             prints.addAll(test.prints);
             continue;
           }
-          _buildTest(
-            builder: builder,
-            test: test,
-            className: className,
-            suitePath: suite.path,
-          );
+          _buildTest(builder: builder, test: test, className: className, suitePath: suite.path);
         }
-        _buildPrints(
-          builder: builder,
-          prints: prints,
-        );
+        _buildPrints(builder: builder, prints: prints);
       },
     );
   }
 
-  void _buildProperties({
-    required XmlBuilder builder,
-    required String? platform,
-  }) {
+  void _buildProperties({required XmlBuilder builder, required String? platform}) {
     if (platform != null) {
       builder.element(
         'properties',
         nest: () {
-          builder.element(
-            'property',
-            attributes: {
-              'name': 'platform',
-              'value': platform,
-            },
-          );
+          builder.element('property', attributes: {'name': 'platform', 'value': platform});
         },
       );
     }
   }
 
-  void _buildTest({
-    required XmlBuilder builder,
-    required Test test,
-    required String className,
-    String? suitePath,
-  }) {
+  void _buildTest({required XmlBuilder builder, required Test test, required String className, String? suitePath}) {
     builder.element(
       'testcase',
       attributes: {
         'classname': className,
-        'file': _buildTestFileName(
-          test: test,
-          suitePath: suitePath,
-        ),
+        'file': _buildTestFileName(test: test, suitePath: suitePath),
         'name': test.name,
         'time': _milliseconds.format(test.duration / 1000.0),
       },
       nest: () {
         if (test.skipped) builder.element('skipped');
-        _buildProblems(
-          builder: builder,
-          problems: test.problems,
-        );
-        _buildPrints(
-          builder: builder,
-          prints: test.prints,
-        );
+        _buildProblems(builder: builder, problems: test.problems);
+        _buildPrints(builder: builder, prints: test.prints);
       },
     );
   }
 
-  String _buildTestFileName({
-    required Test test,
-    String? suitePath,
-  }) {
+  String _buildTestFileName({required Test test, String? suitePath}) {
     final path = test.rootUrl ?? suitePath ?? test.url ?? 'unknown_file';
     return _convertPathToRelativePath(path);
   }
 
-  void _buildPrints({
-    required XmlBuilder builder,
-    required List<String> prints,
-  }) {
+  void _buildPrints({required XmlBuilder builder, required List<String> prints}) {
     if (prints.isNotEmpty) {
-      builder.element(
-        'system-out',
-        nest: prints.join('\n'),
-      );
+      builder.element('system-out', nest: prints.join('\n'));
     }
   }
 
-  void _buildProblems({
-    required XmlBuilder builder,
-    required List<Problem> problems,
-  }) {
+  void _buildProblems({required XmlBuilder builder, required List<Problem> problems}) {
     if (problems.isNotEmpty) {
       final failures = problems.where((p) => p.isFailure);
       final errors = problems.where((p) => !p.isFailure);
-      final details = <String>[
-        ..._details(failures),
-        ..._details(errors),
-      ];
+      final details = <String>[..._details(failures), ..._details(errors)];
 
       final type = errors.isEmpty ? 'failure' : 'error';
       builder.element(
         type,
-        attributes: {
-          'message': _message(
-            failures: failures.length,
-            errors: errors.length,
-          ),
-        },
+        attributes: {'message': _message(failures: failures.length, errors: errors.length)},
         nest: details.join(r'\n\n\n'),
       );
     }
@@ -227,8 +156,7 @@ class TestJsonToJunit {
       main = main.substring(0, main.length - '.dart'.length);
     }
 
-    final mainResult =
-        main.replaceAll(Platform.pathSeparator, '.').replaceAll('-', '_');
+    final mainResult = main.replaceAll(Platform.pathSeparator, '.').replaceAll('-', '_');
 
     return mainResult;
   }
@@ -236,20 +164,10 @@ class TestJsonToJunit {
   Iterable<String> _details(Iterable<Problem> problems) {
     final more = problems.length > 1;
     var count = 0;
-    return problems.map(
-      (problem) => _report(
-        more: more,
-        index: ++count,
-        problem: problem,
-      ),
-    );
+    return problems.map((problem) => _report(more: more, index: ++count, problem: problem));
   }
 
-  String _report({
-    required bool more,
-    required int index,
-    required Problem problem,
-  }) {
+  String _report({required bool more, required int index, required Problem problem}) {
     final message = problem.message;
     var stacktrace = problem.stacktrace;
     var short = '';
@@ -275,10 +193,7 @@ class TestJsonToJunit {
     return report.join(r'\n\n');
   }
 
-  String _message({
-    required int failures,
-    required int errors,
-  }) {
+  String _message({required int failures, required int errors}) {
     final texts = <String>[];
     if (failures == 1) texts.add('1 failure');
     if (failures > 1) texts.add('$failures failures');

--- a/lib/src/junit_xml/test_json_to_junit.dart
+++ b/lib/src/junit_xml/test_json_to_junit.dart
@@ -26,7 +26,11 @@ class TestJsonToJunit {
       'testsuites',
       nest: () {
         for (final suite in report.suites) {
-          _buildSuite(builder: builder, suite: suite, timestamp: report.timestamp);
+          _buildSuite(
+            builder: builder,
+            suite: suite,
+            timestamp: report.timestamp,
+          );
         }
       },
     );
@@ -41,11 +45,17 @@ class TestJsonToJunit {
     );
   }
 
-  void _buildSuite({required XmlBuilder builder, required Suite suite, DateTime? timestamp}) {
+  void _buildSuite({
+    required XmlBuilder builder,
+    required Suite suite,
+    DateTime? timestamp,
+  }) {
     final className = _convertPathToClassName(suite.path);
     final attributes = <String, String>{
-      'errors': '${suite.problems.where((t) => !t.problems.every((p) => p.isFailure)).length}',
-      'failures': '${suite.problems.where((t) => t.problems.every((p) => p.isFailure)).length}',
+      'errors':
+          '${suite.problems.where((t) => !t.problems.every((p) => p.isFailure)).length}',
+      'failures':
+          '${suite.problems.where((t) => t.problems.every((p) => p.isFailure)).length}',
       'tests': '${suite.tests.length}',
       'skipped': '${suite.skipped.length}',
       'name': className,
@@ -62,25 +72,41 @@ class TestJsonToJunit {
             prints.addAll(test.prints);
             continue;
           }
-          _buildTest(builder: builder, test: test, className: className, suitePath: suite.path);
+          _buildTest(
+            builder: builder,
+            test: test,
+            className: className,
+            suitePath: suite.path,
+          );
         }
         _buildPrints(builder: builder, prints: prints);
       },
     );
   }
 
-  void _buildProperties({required XmlBuilder builder, required String? platform}) {
+  void _buildProperties({
+    required XmlBuilder builder,
+    required String? platform,
+  }) {
     if (platform != null) {
       builder.element(
         'properties',
         nest: () {
-          builder.element('property', attributes: {'name': 'platform', 'value': platform});
+          builder.element(
+            'property',
+            attributes: {'name': 'platform', 'value': platform},
+          );
         },
       );
     }
   }
 
-  void _buildTest({required XmlBuilder builder, required Test test, required String className, String? suitePath}) {
+  void _buildTest({
+    required XmlBuilder builder,
+    required Test test,
+    required String className,
+    String? suitePath,
+  }) {
     builder.element(
       'testcase',
       attributes: {
@@ -102,13 +128,19 @@ class TestJsonToJunit {
     return _convertPathToRelativePath(path);
   }
 
-  void _buildPrints({required XmlBuilder builder, required List<String> prints}) {
+  void _buildPrints({
+    required XmlBuilder builder,
+    required List<String> prints,
+  }) {
     if (prints.isNotEmpty) {
       builder.element('system-out', nest: prints.join('\n'));
     }
   }
 
-  void _buildProblems({required XmlBuilder builder, required List<Problem> problems}) {
+  void _buildProblems({
+    required XmlBuilder builder,
+    required List<Problem> problems,
+  }) {
     if (problems.isNotEmpty) {
       final failures = problems.where((p) => p.isFailure);
       final errors = problems.where((p) => !p.isFailure);
@@ -117,7 +149,9 @@ class TestJsonToJunit {
       final type = errors.isEmpty ? 'failure' : 'error';
       builder.element(
         type,
-        attributes: {'message': _message(failures: failures.length, errors: errors.length)},
+        attributes: {
+          'message': _message(failures: failures.length, errors: errors.length),
+        },
         nest: details.join(r'\n\n\n'),
       );
     }
@@ -156,7 +190,9 @@ class TestJsonToJunit {
       main = main.substring(0, main.length - '.dart'.length);
     }
 
-    final mainResult = main.replaceAll(Platform.pathSeparator, '.').replaceAll('-', '_');
+    final mainResult = main
+        .replaceAll(Platform.pathSeparator, '.')
+        .replaceAll('-', '_');
 
     return mainResult;
   }
@@ -164,10 +200,16 @@ class TestJsonToJunit {
   Iterable<String> _details(Iterable<Problem> problems) {
     final more = problems.length > 1;
     var count = 0;
-    return problems.map((problem) => _report(more: more, index: ++count, problem: problem));
+    return problems.map(
+      (problem) => _report(more: more, index: ++count, problem: problem),
+    );
   }
 
-  String _report({required bool more, required int index, required Problem problem}) {
+  String _report({
+    required bool more,
+    required int index,
+    required Problem problem,
+  }) {
     final message = problem.message;
     var stacktrace = problem.stacktrace;
     var short = '';

--- a/lib/src/parser/json_reporter_protocol_0_1/event.dart
+++ b/lib/src/parser/json_reporter_protocol_0_1/event.dart
@@ -6,10 +6,7 @@ part 'event.freezed.dart';
 part 'event.g.dart';
 
 /// Events as defined by [json reporter](https://github.com/dart-lang/test/blob/master/pkgs/test/doc/json_reporter.md#events)
-@Freezed(
-  unionKey: 'type',
-  fallbackUnion: 'unknown',
-)
+@Freezed(unionKey: 'type', fallbackUnion: 'unknown')
 class Event with _$Event {
   // coverage:ignore-start
 

--- a/lib/src/parser/json_reporter_protocol_0_1/event.freezed.dart
+++ b/lib/src/parser/json_reporter_protocol_0_1/event.freezed.dart
@@ -49,7 +49,13 @@ mixin _$Event {
   int get time => throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
+    required TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )
+    start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -61,7 +67,13 @@ mixin _$Event {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )
+    print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -83,14 +95,31 @@ mixin _$Event {
   }) => throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult? Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult? Function(int time, int count)? allSuites,
     TResult? Function(int time, Suite suite)? suite,
-    TResult? Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult? Function(int time, Group group)? group,
     TResult? Function(int time, Test test)? testStart,
-    TResult? Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -112,14 +141,31 @@ mixin _$Event {
   }) => throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -195,13 +241,15 @@ mixin _$Event {
 
 /// @nodoc
 abstract class $EventCopyWith<$Res> {
-  factory $EventCopyWith(Event value, $Res Function(Event) then) = _$EventCopyWithImpl<$Res, Event>;
+  factory $EventCopyWith(Event value, $Res Function(Event) then) =
+      _$EventCopyWithImpl<$Res, Event>;
   @useResult
   $Res call({int time});
 }
 
 /// @nodoc
-class _$EventCopyWithImpl<$Res, $Val extends Event> implements $EventCopyWith<$Res> {
+class _$EventCopyWithImpl<$Res, $Val extends Event>
+    implements $EventCopyWith<$Res> {
   _$EventCopyWithImpl(this._value, this._then);
 
   // ignore: unused_field
@@ -229,16 +277,23 @@ class _$EventCopyWithImpl<$Res, $Val extends Event> implements $EventCopyWith<$R
 
 /// @nodoc
 abstract class _$$StartImplCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$StartImplCopyWith(_$StartImpl value, $Res Function(_$StartImpl) then) = __$$StartImplCopyWithImpl<$Res>;
+  factory _$$StartImplCopyWith(
+    _$StartImpl value,
+    $Res Function(_$StartImpl) then,
+  ) = __$$StartImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int time, String protocolVersion, String? runnerVersion, int pid});
 }
 
 /// @nodoc
-class __$$StartImplCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res, _$StartImpl>
+class __$$StartImplCopyWithImpl<$Res>
+    extends _$EventCopyWithImpl<$Res, _$StartImpl>
     implements _$$StartImplCopyWith<$Res> {
-  __$$StartImplCopyWithImpl(_$StartImpl _value, $Res Function(_$StartImpl) _then) : super(_value, _then);
+  __$$StartImplCopyWithImpl(
+    _$StartImpl _value,
+    $Res Function(_$StartImpl) _then,
+  ) : super(_value, _then);
 
   /// Create a copy of Event
   /// with the given fields replaced by the non-null parameter values.
@@ -288,7 +343,8 @@ class _$StartImpl implements _Start {
     final String? $type,
   }) : $type = $type ?? 'start';
 
-  factory _$StartImpl.fromJson(Map<String, dynamic> json) => _$$StartImplFromJson(json);
+  factory _$StartImpl.fromJson(Map<String, dynamic> json) =>
+      _$$StartImplFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -325,26 +381,36 @@ class _$StartImpl implements _Start {
         (other.runtimeType == runtimeType &&
             other is _$StartImpl &&
             (identical(other.time, time) || other.time == time) &&
-            (identical(other.protocolVersion, protocolVersion) || other.protocolVersion == protocolVersion) &&
-            (identical(other.runnerVersion, runnerVersion) || other.runnerVersion == runnerVersion) &&
+            (identical(other.protocolVersion, protocolVersion) ||
+                other.protocolVersion == protocolVersion) &&
+            (identical(other.runnerVersion, runnerVersion) ||
+                other.runnerVersion == runnerVersion) &&
             (identical(other.pid, pid) || other.pid == pid));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(runtimeType, time, protocolVersion, runnerVersion, pid);
+  int get hashCode =>
+      Object.hash(runtimeType, time, protocolVersion, runnerVersion, pid);
 
   /// Create a copy of Event
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$StartImplCopyWith<_$StartImpl> get copyWith => __$$StartImplCopyWithImpl<_$StartImpl>(this, _$identity);
+  _$$StartImplCopyWith<_$StartImpl> get copyWith =>
+      __$$StartImplCopyWithImpl<_$StartImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
+    required TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )
+    start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -356,7 +422,13 @@ class _$StartImpl implements _Start {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )
+    print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -382,14 +454,31 @@ class _$StartImpl implements _Start {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult? Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult? Function(int time, int count)? allSuites,
     TResult? Function(int time, Suite suite)? suite,
-    TResult? Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult? Function(int time, Group group)? group,
     TResult? Function(int time, Test test)? testStart,
-    TResult? Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -415,14 +504,31 @@ class _$StartImpl implements _Start {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -545,22 +651,29 @@ abstract class _Start implements Event {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$StartImplCopyWith<_$StartImpl> get copyWith => throw _privateConstructorUsedError;
+  _$$StartImplCopyWith<_$StartImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$AllSuitesImplCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$AllSuitesImplCopyWith(_$AllSuitesImpl value, $Res Function(_$AllSuitesImpl) then) =
-      __$$AllSuitesImplCopyWithImpl<$Res>;
+  factory _$$AllSuitesImplCopyWith(
+    _$AllSuitesImpl value,
+    $Res Function(_$AllSuitesImpl) then,
+  ) = __$$AllSuitesImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int time, int count});
 }
 
 /// @nodoc
-class __$$AllSuitesImplCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res, _$AllSuitesImpl>
+class __$$AllSuitesImplCopyWithImpl<$Res>
+    extends _$EventCopyWithImpl<$Res, _$AllSuitesImpl>
     implements _$$AllSuitesImplCopyWith<$Res> {
-  __$$AllSuitesImplCopyWithImpl(_$AllSuitesImpl _value, $Res Function(_$AllSuitesImpl) _then) : super(_value, _then);
+  __$$AllSuitesImplCopyWithImpl(
+    _$AllSuitesImpl _value,
+    $Res Function(_$AllSuitesImpl) _then,
+  ) : super(_value, _then);
 
   /// Create a copy of Event
   /// with the given fields replaced by the non-null parameter values.
@@ -587,9 +700,14 @@ class __$$AllSuitesImplCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res, _$Al
 /// @nodoc
 @JsonSerializable()
 class _$AllSuitesImpl implements _AllSuites {
-  const _$AllSuitesImpl({required this.time, required this.count, final String? $type}) : $type = $type ?? 'allSuites';
+  const _$AllSuitesImpl({
+    required this.time,
+    required this.count,
+    final String? $type,
+  }) : $type = $type ?? 'allSuites';
 
-  factory _$AllSuitesImpl.fromJson(Map<String, dynamic> json) => _$$AllSuitesImplFromJson(json);
+  factory _$AllSuitesImpl.fromJson(Map<String, dynamic> json) =>
+      _$$AllSuitesImplFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -631,7 +749,13 @@ class _$AllSuitesImpl implements _AllSuites {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
+    required TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )
+    start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -643,7 +767,13 @@ class _$AllSuitesImpl implements _AllSuites {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )
+    print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -669,14 +799,31 @@ class _$AllSuitesImpl implements _AllSuites {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult? Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult? Function(int time, int count)? allSuites,
     TResult? Function(int time, Suite suite)? suite,
-    TResult? Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult? Function(int time, Group group)? group,
     TResult? Function(int time, Test test)? testStart,
-    TResult? Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -702,14 +849,31 @@ class _$AllSuitesImpl implements _AllSuites {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -801,9 +965,13 @@ class _$AllSuitesImpl implements _AllSuites {
 }
 
 abstract class _AllSuites implements Event {
-  const factory _AllSuites({required final int time, required final int count}) = _$AllSuitesImpl;
+  const factory _AllSuites({
+    required final int time,
+    required final int count,
+  }) = _$AllSuitesImpl;
 
-  factory _AllSuites.fromJson(Map<String, dynamic> json) = _$AllSuitesImpl.fromJson;
+  factory _AllSuites.fromJson(Map<String, dynamic> json) =
+      _$AllSuitesImpl.fromJson;
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -816,12 +984,16 @@ abstract class _AllSuites implements Event {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$AllSuitesImplCopyWith<_$AllSuitesImpl> get copyWith => throw _privateConstructorUsedError;
+  _$$AllSuitesImplCopyWith<_$AllSuitesImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$SuiteImplCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$SuiteImplCopyWith(_$SuiteImpl value, $Res Function(_$SuiteImpl) then) = __$$SuiteImplCopyWithImpl<$Res>;
+  factory _$$SuiteImplCopyWith(
+    _$SuiteImpl value,
+    $Res Function(_$SuiteImpl) then,
+  ) = __$$SuiteImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int time, Suite suite});
@@ -830,9 +1002,13 @@ abstract class _$$SuiteImplCopyWith<$Res> implements $EventCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$SuiteImplCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res, _$SuiteImpl>
+class __$$SuiteImplCopyWithImpl<$Res>
+    extends _$EventCopyWithImpl<$Res, _$SuiteImpl>
     implements _$$SuiteImplCopyWith<$Res> {
-  __$$SuiteImplCopyWithImpl(_$SuiteImpl _value, $Res Function(_$SuiteImpl) _then) : super(_value, _then);
+  __$$SuiteImplCopyWithImpl(
+    _$SuiteImpl _value,
+    $Res Function(_$SuiteImpl) _then,
+  ) : super(_value, _then);
 
   /// Create a copy of Event
   /// with the given fields replaced by the non-null parameter values.
@@ -869,9 +1045,14 @@ class __$$SuiteImplCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res, _$SuiteI
 /// @nodoc
 @JsonSerializable()
 class _$SuiteImpl implements _Suite {
-  const _$SuiteImpl({required this.time, required this.suite, final String? $type}) : $type = $type ?? 'suite';
+  const _$SuiteImpl({
+    required this.time,
+    required this.suite,
+    final String? $type,
+  }) : $type = $type ?? 'suite';
 
-  factory _$SuiteImpl.fromJson(Map<String, dynamic> json) => _$$SuiteImplFromJson(json);
+  factory _$SuiteImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SuiteImplFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -907,12 +1088,19 @@ class _$SuiteImpl implements _Suite {
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$SuiteImplCopyWith<_$SuiteImpl> get copyWith => __$$SuiteImplCopyWithImpl<_$SuiteImpl>(this, _$identity);
+  _$$SuiteImplCopyWith<_$SuiteImpl> get copyWith =>
+      __$$SuiteImplCopyWithImpl<_$SuiteImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
+    required TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )
+    start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -924,7 +1112,13 @@ class _$SuiteImpl implements _Suite {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )
+    print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -950,14 +1144,31 @@ class _$SuiteImpl implements _Suite {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult? Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult? Function(int time, int count)? allSuites,
     TResult? Function(int time, Suite suite)? suite,
-    TResult? Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult? Function(int time, Group group)? group,
     TResult? Function(int time, Test test)? testStart,
-    TResult? Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -983,14 +1194,31 @@ class _$SuiteImpl implements _Suite {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -1082,7 +1310,8 @@ class _$SuiteImpl implements _Suite {
 }
 
 abstract class _Suite implements Event {
-  const factory _Suite({required final int time, required final Suite suite}) = _$SuiteImpl;
+  const factory _Suite({required final int time, required final Suite suite}) =
+      _$SuiteImpl;
 
   factory _Suite.fromJson(Map<String, dynamic> json) = _$SuiteImpl.fromJson;
 
@@ -1097,21 +1326,34 @@ abstract class _Suite implements Event {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$SuiteImplCopyWith<_$SuiteImpl> get copyWith => throw _privateConstructorUsedError;
+  _$$SuiteImplCopyWith<_$SuiteImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$DebugImplCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$DebugImplCopyWith(_$DebugImpl value, $Res Function(_$DebugImpl) then) = __$$DebugImplCopyWithImpl<$Res>;
+  factory _$$DebugImplCopyWith(
+    _$DebugImpl value,
+    $Res Function(_$DebugImpl) then,
+  ) = __$$DebugImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger});
+  $Res call({
+    int time,
+    @JsonKey(name: 'suiteID') int suiteId,
+    String? observatory,
+    String? remoteDebugger,
+  });
 }
 
 /// @nodoc
-class __$$DebugImplCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res, _$DebugImpl>
+class __$$DebugImplCopyWithImpl<$Res>
+    extends _$EventCopyWithImpl<$Res, _$DebugImpl>
     implements _$$DebugImplCopyWith<$Res> {
-  __$$DebugImplCopyWithImpl(_$DebugImpl _value, $Res Function(_$DebugImpl) _then) : super(_value, _then);
+  __$$DebugImplCopyWithImpl(
+    _$DebugImpl _value,
+    $Res Function(_$DebugImpl) _then,
+  ) : super(_value, _then);
 
   /// Create a copy of Event
   /// with the given fields replaced by the non-null parameter values.
@@ -1161,7 +1403,8 @@ class _$DebugImpl implements _Debug {
     final String? $type,
   }) : $type = $type ?? 'debug';
 
-  factory _$DebugImpl.fromJson(Map<String, dynamic> json) => _$$DebugImplFromJson(json);
+  factory _$DebugImpl.fromJson(Map<String, dynamic> json) =>
+      _$$DebugImplFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -1195,25 +1438,35 @@ class _$DebugImpl implements _Debug {
             other is _$DebugImpl &&
             (identical(other.time, time) || other.time == time) &&
             (identical(other.suiteId, suiteId) || other.suiteId == suiteId) &&
-            (identical(other.observatory, observatory) || other.observatory == observatory) &&
-            (identical(other.remoteDebugger, remoteDebugger) || other.remoteDebugger == remoteDebugger));
+            (identical(other.observatory, observatory) ||
+                other.observatory == observatory) &&
+            (identical(other.remoteDebugger, remoteDebugger) ||
+                other.remoteDebugger == remoteDebugger));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(runtimeType, time, suiteId, observatory, remoteDebugger);
+  int get hashCode =>
+      Object.hash(runtimeType, time, suiteId, observatory, remoteDebugger);
 
   /// Create a copy of Event
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$DebugImplCopyWith<_$DebugImpl> get copyWith => __$$DebugImplCopyWithImpl<_$DebugImpl>(this, _$identity);
+  _$$DebugImplCopyWith<_$DebugImpl> get copyWith =>
+      __$$DebugImplCopyWithImpl<_$DebugImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
+    required TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )
+    start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -1225,7 +1478,13 @@ class _$DebugImpl implements _Debug {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )
+    print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -1251,14 +1510,31 @@ class _$DebugImpl implements _Debug {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult? Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult? Function(int time, int count)? allSuites,
     TResult? Function(int time, Suite suite)? suite,
-    TResult? Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult? Function(int time, Group group)? group,
     TResult? Function(int time, Test test)? testStart,
-    TResult? Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -1284,14 +1560,31 @@ class _$DebugImpl implements _Debug {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -1410,12 +1703,16 @@ abstract class _Debug implements Event {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$DebugImplCopyWith<_$DebugImpl> get copyWith => throw _privateConstructorUsedError;
+  _$$DebugImplCopyWith<_$DebugImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$GroupImplCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$GroupImplCopyWith(_$GroupImpl value, $Res Function(_$GroupImpl) then) = __$$GroupImplCopyWithImpl<$Res>;
+  factory _$$GroupImplCopyWith(
+    _$GroupImpl value,
+    $Res Function(_$GroupImpl) then,
+  ) = __$$GroupImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int time, Group group});
@@ -1424,9 +1721,13 @@ abstract class _$$GroupImplCopyWith<$Res> implements $EventCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$GroupImplCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res, _$GroupImpl>
+class __$$GroupImplCopyWithImpl<$Res>
+    extends _$EventCopyWithImpl<$Res, _$GroupImpl>
     implements _$$GroupImplCopyWith<$Res> {
-  __$$GroupImplCopyWithImpl(_$GroupImpl _value, $Res Function(_$GroupImpl) _then) : super(_value, _then);
+  __$$GroupImplCopyWithImpl(
+    _$GroupImpl _value,
+    $Res Function(_$GroupImpl) _then,
+  ) : super(_value, _then);
 
   /// Create a copy of Event
   /// with the given fields replaced by the non-null parameter values.
@@ -1463,9 +1764,14 @@ class __$$GroupImplCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res, _$GroupI
 /// @nodoc
 @JsonSerializable()
 class _$GroupImpl implements _Group {
-  const _$GroupImpl({required this.time, required this.group, final String? $type}) : $type = $type ?? 'group';
+  const _$GroupImpl({
+    required this.time,
+    required this.group,
+    final String? $type,
+  }) : $type = $type ?? 'group';
 
-  factory _$GroupImpl.fromJson(Map<String, dynamic> json) => _$$GroupImplFromJson(json);
+  factory _$GroupImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GroupImplFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -1501,12 +1807,19 @@ class _$GroupImpl implements _Group {
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$GroupImplCopyWith<_$GroupImpl> get copyWith => __$$GroupImplCopyWithImpl<_$GroupImpl>(this, _$identity);
+  _$$GroupImplCopyWith<_$GroupImpl> get copyWith =>
+      __$$GroupImplCopyWithImpl<_$GroupImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
+    required TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )
+    start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -1518,7 +1831,13 @@ class _$GroupImpl implements _Group {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )
+    print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -1544,14 +1863,31 @@ class _$GroupImpl implements _Group {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult? Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult? Function(int time, int count)? allSuites,
     TResult? Function(int time, Suite suite)? suite,
-    TResult? Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult? Function(int time, Group group)? group,
     TResult? Function(int time, Test test)? testStart,
-    TResult? Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -1577,14 +1913,31 @@ class _$GroupImpl implements _Group {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -1676,7 +2029,8 @@ class _$GroupImpl implements _Group {
 }
 
 abstract class _Group implements Event {
-  const factory _Group({required final int time, required final Group group}) = _$GroupImpl;
+  const factory _Group({required final int time, required final Group group}) =
+      _$GroupImpl;
 
   factory _Group.fromJson(Map<String, dynamic> json) = _$GroupImpl.fromJson;
 
@@ -1691,13 +2045,16 @@ abstract class _Group implements Event {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$GroupImplCopyWith<_$GroupImpl> get copyWith => throw _privateConstructorUsedError;
+  _$$GroupImplCopyWith<_$GroupImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$TestStartImplCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$TestStartImplCopyWith(_$TestStartImpl value, $Res Function(_$TestStartImpl) then) =
-      __$$TestStartImplCopyWithImpl<$Res>;
+  factory _$$TestStartImplCopyWith(
+    _$TestStartImpl value,
+    $Res Function(_$TestStartImpl) then,
+  ) = __$$TestStartImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int time, Test test});
@@ -1706,9 +2063,13 @@ abstract class _$$TestStartImplCopyWith<$Res> implements $EventCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$TestStartImplCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res, _$TestStartImpl>
+class __$$TestStartImplCopyWithImpl<$Res>
+    extends _$EventCopyWithImpl<$Res, _$TestStartImpl>
     implements _$$TestStartImplCopyWith<$Res> {
-  __$$TestStartImplCopyWithImpl(_$TestStartImpl _value, $Res Function(_$TestStartImpl) _then) : super(_value, _then);
+  __$$TestStartImplCopyWithImpl(
+    _$TestStartImpl _value,
+    $Res Function(_$TestStartImpl) _then,
+  ) : super(_value, _then);
 
   /// Create a copy of Event
   /// with the given fields replaced by the non-null parameter values.
@@ -1745,9 +2106,14 @@ class __$$TestStartImplCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res, _$Te
 /// @nodoc
 @JsonSerializable()
 class _$TestStartImpl implements _TestStart {
-  const _$TestStartImpl({required this.time, required this.test, final String? $type}) : $type = $type ?? 'testStart';
+  const _$TestStartImpl({
+    required this.time,
+    required this.test,
+    final String? $type,
+  }) : $type = $type ?? 'testStart';
 
-  factory _$TestStartImpl.fromJson(Map<String, dynamic> json) => _$$TestStartImplFromJson(json);
+  factory _$TestStartImpl.fromJson(Map<String, dynamic> json) =>
+      _$$TestStartImplFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -1789,7 +2155,13 @@ class _$TestStartImpl implements _TestStart {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
+    required TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )
+    start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -1801,7 +2173,13 @@ class _$TestStartImpl implements _TestStart {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )
+    print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -1827,14 +2205,31 @@ class _$TestStartImpl implements _TestStart {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult? Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult? Function(int time, int count)? allSuites,
     TResult? Function(int time, Suite suite)? suite,
-    TResult? Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult? Function(int time, Group group)? group,
     TResult? Function(int time, Test test)? testStart,
-    TResult? Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -1860,14 +2255,31 @@ class _$TestStartImpl implements _TestStart {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -1959,9 +2371,13 @@ class _$TestStartImpl implements _TestStart {
 }
 
 abstract class _TestStart implements Event {
-  const factory _TestStart({required final int time, required final Test test}) = _$TestStartImpl;
+  const factory _TestStart({
+    required final int time,
+    required final Test test,
+  }) = _$TestStartImpl;
 
-  factory _TestStart.fromJson(Map<String, dynamic> json) = _$TestStartImpl.fromJson;
+  factory _TestStart.fromJson(Map<String, dynamic> json) =
+      _$TestStartImpl.fromJson;
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -1974,27 +2390,45 @@ abstract class _TestStart implements Event {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$TestStartImplCopyWith<_$TestStartImpl> get copyWith => throw _privateConstructorUsedError;
+  _$$TestStartImplCopyWith<_$TestStartImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$PrintImplCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$PrintImplCopyWith(_$PrintImpl value, $Res Function(_$PrintImpl) then) = __$$PrintImplCopyWithImpl<$Res>;
+  factory _$$PrintImplCopyWith(
+    _$PrintImpl value,
+    $Res Function(_$PrintImpl) then,
+  ) = __$$PrintImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({int time, @JsonKey(name: 'testID') int testId, String messageType, String message});
+  $Res call({
+    int time,
+    @JsonKey(name: 'testID') int testId,
+    String messageType,
+    String message,
+  });
 }
 
 /// @nodoc
-class __$$PrintImplCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res, _$PrintImpl>
+class __$$PrintImplCopyWithImpl<$Res>
+    extends _$EventCopyWithImpl<$Res, _$PrintImpl>
     implements _$$PrintImplCopyWith<$Res> {
-  __$$PrintImplCopyWithImpl(_$PrintImpl _value, $Res Function(_$PrintImpl) _then) : super(_value, _then);
+  __$$PrintImplCopyWithImpl(
+    _$PrintImpl _value,
+    $Res Function(_$PrintImpl) _then,
+  ) : super(_value, _then);
 
   /// Create a copy of Event
   /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
-  $Res call({Object? time = null, Object? testId = null, Object? messageType = null, Object? message = null}) {
+  $Res call({
+    Object? time = null,
+    Object? testId = null,
+    Object? messageType = null,
+    Object? message = null,
+  }) {
     return _then(
       _$PrintImpl(
         time:
@@ -2033,7 +2467,8 @@ class _$PrintImpl implements _Print {
     final String? $type,
   }) : $type = $type ?? 'print';
 
-  factory _$PrintImpl.fromJson(Map<String, dynamic> json) => _$$PrintImplFromJson(json);
+  factory _$PrintImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PrintImplFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -2067,25 +2502,34 @@ class _$PrintImpl implements _Print {
             other is _$PrintImpl &&
             (identical(other.time, time) || other.time == time) &&
             (identical(other.testId, testId) || other.testId == testId) &&
-            (identical(other.messageType, messageType) || other.messageType == messageType) &&
+            (identical(other.messageType, messageType) ||
+                other.messageType == messageType) &&
             (identical(other.message, message) || other.message == message));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(runtimeType, time, testId, messageType, message);
+  int get hashCode =>
+      Object.hash(runtimeType, time, testId, messageType, message);
 
   /// Create a copy of Event
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$PrintImplCopyWith<_$PrintImpl> get copyWith => __$$PrintImplCopyWithImpl<_$PrintImpl>(this, _$identity);
+  _$$PrintImplCopyWith<_$PrintImpl> get copyWith =>
+      __$$PrintImplCopyWithImpl<_$PrintImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
+    required TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )
+    start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -2097,7 +2541,13 @@ class _$PrintImpl implements _Print {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )
+    print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -2123,14 +2573,31 @@ class _$PrintImpl implements _Print {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult? Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult? Function(int time, int count)? allSuites,
     TResult? Function(int time, Suite suite)? suite,
-    TResult? Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult? Function(int time, Group group)? group,
     TResult? Function(int time, Test test)? testStart,
-    TResult? Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -2156,14 +2623,31 @@ class _$PrintImpl implements _Print {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -2282,12 +2766,16 @@ abstract class _Print implements Event {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$PrintImplCopyWith<_$PrintImpl> get copyWith => throw _privateConstructorUsedError;
+  _$$PrintImplCopyWith<_$PrintImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$ErrorImplCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$ErrorImplCopyWith(_$ErrorImpl value, $Res Function(_$ErrorImpl) then) = __$$ErrorImplCopyWithImpl<$Res>;
+  factory _$$ErrorImplCopyWith(
+    _$ErrorImpl value,
+    $Res Function(_$ErrorImpl) then,
+  ) = __$$ErrorImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({
@@ -2300,9 +2788,13 @@ abstract class _$$ErrorImplCopyWith<$Res> implements $EventCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$ErrorImplCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res, _$ErrorImpl>
+class __$$ErrorImplCopyWithImpl<$Res>
+    extends _$EventCopyWithImpl<$Res, _$ErrorImpl>
     implements _$$ErrorImplCopyWith<$Res> {
-  __$$ErrorImplCopyWithImpl(_$ErrorImpl _value, $Res Function(_$ErrorImpl) _then) : super(_value, _then);
+  __$$ErrorImplCopyWithImpl(
+    _$ErrorImpl _value,
+    $Res Function(_$ErrorImpl) _then,
+  ) : super(_value, _then);
 
   /// Create a copy of Event
   /// with the given fields replaced by the non-null parameter values.
@@ -2359,7 +2851,8 @@ class _$ErrorImpl implements _Error {
     final String? $type,
   }) : $type = $type ?? 'error';
 
-  factory _$ErrorImpl.fromJson(Map<String, dynamic> json) => _$$ErrorImplFromJson(json);
+  factory _$ErrorImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ErrorImplFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -2399,25 +2892,35 @@ class _$ErrorImpl implements _Error {
             (identical(other.time, time) || other.time == time) &&
             (identical(other.testId, testId) || other.testId == testId) &&
             (identical(other.error, error) || other.error == error) &&
-            (identical(other.stacktrace, stacktrace) || other.stacktrace == stacktrace) &&
-            (identical(other.isFailure, isFailure) || other.isFailure == isFailure));
+            (identical(other.stacktrace, stacktrace) ||
+                other.stacktrace == stacktrace) &&
+            (identical(other.isFailure, isFailure) ||
+                other.isFailure == isFailure));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(runtimeType, time, testId, error, stacktrace, isFailure);
+  int get hashCode =>
+      Object.hash(runtimeType, time, testId, error, stacktrace, isFailure);
 
   /// Create a copy of Event
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$ErrorImplCopyWith<_$ErrorImpl> get copyWith => __$$ErrorImplCopyWithImpl<_$ErrorImpl>(this, _$identity);
+  _$$ErrorImplCopyWith<_$ErrorImpl> get copyWith =>
+      __$$ErrorImplCopyWithImpl<_$ErrorImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
+    required TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )
+    start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -2429,7 +2932,13 @@ class _$ErrorImpl implements _Error {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )
+    print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -2455,14 +2964,31 @@ class _$ErrorImpl implements _Error {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult? Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult? Function(int time, int count)? allSuites,
     TResult? Function(int time, Suite suite)? suite,
-    TResult? Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult? Function(int time, Group group)? group,
     TResult? Function(int time, Test test)? testStart,
-    TResult? Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -2488,14 +3014,31 @@ class _$ErrorImpl implements _Error {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -2619,13 +3162,16 @@ abstract class _Error implements Event {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$ErrorImplCopyWith<_$ErrorImpl> get copyWith => throw _privateConstructorUsedError;
+  _$$ErrorImplCopyWith<_$ErrorImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$TestDoneImplCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$TestDoneImplCopyWith(_$TestDoneImpl value, $Res Function(_$TestDoneImpl) then) =
-      __$$TestDoneImplCopyWithImpl<$Res>;
+  factory _$$TestDoneImplCopyWith(
+    _$TestDoneImpl value,
+    $Res Function(_$TestDoneImpl) then,
+  ) = __$$TestDoneImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({
@@ -2638,9 +3184,13 @@ abstract class _$$TestDoneImplCopyWith<$Res> implements $EventCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$TestDoneImplCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res, _$TestDoneImpl>
+class __$$TestDoneImplCopyWithImpl<$Res>
+    extends _$EventCopyWithImpl<$Res, _$TestDoneImpl>
     implements _$$TestDoneImplCopyWith<$Res> {
-  __$$TestDoneImplCopyWithImpl(_$TestDoneImpl _value, $Res Function(_$TestDoneImpl) _then) : super(_value, _then);
+  __$$TestDoneImplCopyWithImpl(
+    _$TestDoneImpl _value,
+    $Res Function(_$TestDoneImpl) _then,
+  ) : super(_value, _then);
 
   /// Create a copy of Event
   /// with the given fields replaced by the non-null parameter values.
@@ -2697,7 +3247,8 @@ class _$TestDoneImpl implements _TestDone {
     final String? $type,
   }) : $type = $type ?? 'testDone';
 
-  factory _$TestDoneImpl.fromJson(Map<String, dynamic> json) => _$$TestDoneImplFromJson(json);
+  factory _$TestDoneImpl.fromJson(Map<String, dynamic> json) =>
+      _$$TestDoneImplFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -2743,7 +3294,8 @@ class _$TestDoneImpl implements _TestDone {
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(runtimeType, time, result, testId, hidden, skipped);
+  int get hashCode =>
+      Object.hash(runtimeType, time, result, testId, hidden, skipped);
 
   /// Create a copy of Event
   /// with the given fields replaced by the non-null parameter values.
@@ -2756,7 +3308,13 @@ class _$TestDoneImpl implements _TestDone {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
+    required TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )
+    start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -2768,7 +3326,13 @@ class _$TestDoneImpl implements _TestDone {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )
+    print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -2794,14 +3358,31 @@ class _$TestDoneImpl implements _TestDone {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult? Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult? Function(int time, int count)? allSuites,
     TResult? Function(int time, Suite suite)? suite,
-    TResult? Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult? Function(int time, Group group)? group,
     TResult? Function(int time, Test test)? testStart,
-    TResult? Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -2827,14 +3408,31 @@ class _$TestDoneImpl implements _TestDone {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -2928,13 +3526,15 @@ class _$TestDoneImpl implements _TestDone {
 abstract class _TestDone implements Event {
   const factory _TestDone({
     required final int time,
-    @JsonKey(unknownEnumValue: TestResult.unknown) required final TestResult result,
+    @JsonKey(unknownEnumValue: TestResult.unknown)
+    required final TestResult result,
     @JsonKey(name: 'testID') required final int testId,
     required final bool hidden,
     required final bool skipped,
   }) = _$TestDoneImpl;
 
-  factory _TestDone.fromJson(Map<String, dynamic> json) = _$TestDoneImpl.fromJson;
+  factory _TestDone.fromJson(Map<String, dynamic> json) =
+      _$TestDoneImpl.fromJson;
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -2958,21 +3558,27 @@ abstract class _TestDone implements Event {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$TestDoneImplCopyWith<_$TestDoneImpl> get copyWith => throw _privateConstructorUsedError;
+  _$$TestDoneImplCopyWith<_$TestDoneImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$DoneImplCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$DoneImplCopyWith(_$DoneImpl value, $Res Function(_$DoneImpl) then) = __$$DoneImplCopyWithImpl<$Res>;
+  factory _$$DoneImplCopyWith(
+    _$DoneImpl value,
+    $Res Function(_$DoneImpl) then,
+  ) = __$$DoneImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int time, bool? success});
 }
 
 /// @nodoc
-class __$$DoneImplCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res, _$DoneImpl>
+class __$$DoneImplCopyWithImpl<$Res>
+    extends _$EventCopyWithImpl<$Res, _$DoneImpl>
     implements _$$DoneImplCopyWith<$Res> {
-  __$$DoneImplCopyWithImpl(_$DoneImpl _value, $Res Function(_$DoneImpl) _then) : super(_value, _then);
+  __$$DoneImplCopyWithImpl(_$DoneImpl _value, $Res Function(_$DoneImpl) _then)
+    : super(_value, _then);
 
   /// Create a copy of Event
   /// with the given fields replaced by the non-null parameter values.
@@ -2999,9 +3605,11 @@ class __$$DoneImplCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res, _$DoneImp
 /// @nodoc
 @JsonSerializable()
 class _$DoneImpl implements _Done {
-  const _$DoneImpl({required this.time, this.success, final String? $type}) : $type = $type ?? 'done';
+  const _$DoneImpl({required this.time, this.success, final String? $type})
+    : $type = $type ?? 'done';
 
-  factory _$DoneImpl.fromJson(Map<String, dynamic> json) => _$$DoneImplFromJson(json);
+  factory _$DoneImpl.fromJson(Map<String, dynamic> json) =>
+      _$$DoneImplFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -3040,12 +3648,19 @@ class _$DoneImpl implements _Done {
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$DoneImplCopyWith<_$DoneImpl> get copyWith => __$$DoneImplCopyWithImpl<_$DoneImpl>(this, _$identity);
+  _$$DoneImplCopyWith<_$DoneImpl> get copyWith =>
+      __$$DoneImplCopyWithImpl<_$DoneImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
+    required TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )
+    start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -3057,7 +3672,13 @@ class _$DoneImpl implements _Done {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )
+    print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -3083,14 +3704,31 @@ class _$DoneImpl implements _Done {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult? Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult? Function(int time, int count)? allSuites,
     TResult? Function(int time, Suite suite)? suite,
-    TResult? Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult? Function(int time, Group group)? group,
     TResult? Function(int time, Test test)? testStart,
-    TResult? Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -3116,14 +3754,31 @@ class _$DoneImpl implements _Done {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -3215,7 +3870,8 @@ class _$DoneImpl implements _Done {
 }
 
 abstract class _Done implements Event {
-  const factory _Done({required final int time, final bool? success}) = _$DoneImpl;
+  const factory _Done({required final int time, final bool? success}) =
+      _$DoneImpl;
 
   factory _Done.fromJson(Map<String, dynamic> json) = _$DoneImpl.fromJson;
 
@@ -3233,22 +3889,29 @@ abstract class _Done implements Event {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$DoneImplCopyWith<_$DoneImpl> get copyWith => throw _privateConstructorUsedError;
+  _$$DoneImplCopyWith<_$DoneImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$UnknownImplCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$UnknownImplCopyWith(_$UnknownImpl value, $Res Function(_$UnknownImpl) then) =
-      __$$UnknownImplCopyWithImpl<$Res>;
+  factory _$$UnknownImplCopyWith(
+    _$UnknownImpl value,
+    $Res Function(_$UnknownImpl) then,
+  ) = __$$UnknownImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int time});
 }
 
 /// @nodoc
-class __$$UnknownImplCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res, _$UnknownImpl>
+class __$$UnknownImplCopyWithImpl<$Res>
+    extends _$EventCopyWithImpl<$Res, _$UnknownImpl>
     implements _$$UnknownImplCopyWith<$Res> {
-  __$$UnknownImplCopyWithImpl(_$UnknownImpl _value, $Res Function(_$UnknownImpl) _then) : super(_value, _then);
+  __$$UnknownImplCopyWithImpl(
+    _$UnknownImpl _value,
+    $Res Function(_$UnknownImpl) _then,
+  ) : super(_value, _then);
 
   /// Create a copy of Event
   /// with the given fields replaced by the non-null parameter values.
@@ -3270,9 +3933,11 @@ class __$$UnknownImplCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res, _$Unkn
 /// @nodoc
 @JsonSerializable()
 class _$UnknownImpl implements _Unknown {
-  const _$UnknownImpl({required this.time, final String? $type}) : $type = $type ?? 'unknown';
+  const _$UnknownImpl({required this.time, final String? $type})
+    : $type = $type ?? 'unknown';
 
-  factory _$UnknownImpl.fromJson(Map<String, dynamic> json) => _$$UnknownImplFromJson(json);
+  factory _$UnknownImpl.fromJson(Map<String, dynamic> json) =>
+      _$$UnknownImplFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -3303,12 +3968,19 @@ class _$UnknownImpl implements _Unknown {
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$UnknownImplCopyWith<_$UnknownImpl> get copyWith => __$$UnknownImplCopyWithImpl<_$UnknownImpl>(this, _$identity);
+  _$$UnknownImplCopyWith<_$UnknownImpl> get copyWith =>
+      __$$UnknownImplCopyWithImpl<_$UnknownImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
+    required TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )
+    start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -3320,7 +3992,13 @@ class _$UnknownImpl implements _Unknown {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )
+    print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -3346,14 +4024,31 @@ class _$UnknownImpl implements _Unknown {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult? Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult? Function(int time, int count)? allSuites,
     TResult? Function(int time, Suite suite)? suite,
-    TResult? Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult? Function(int time, Group group)? group,
     TResult? Function(int time, Test test)? testStart,
-    TResult? Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -3379,14 +4074,31 @@ class _$UnknownImpl implements _Unknown {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -3490,5 +4202,6 @@ abstract class _Unknown implements Event {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$UnknownImplCopyWith<_$UnknownImpl> get copyWith => throw _privateConstructorUsedError;
+  _$$UnknownImplCopyWith<_$UnknownImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }

--- a/lib/src/parser/json_reporter_protocol_0_1/event.freezed.dart
+++ b/lib/src/parser/json_reporter_protocol_0_1/event.freezed.dart
@@ -12,7 +12,8 @@ part of 'event.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods',
+);
 
 Event _$EventFromJson(Map<String, dynamic> json) {
   switch (json['type']) {
@@ -48,104 +49,97 @@ mixin _$Event {
   int get time => throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)
-        start,
+    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
-    required TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)
-        debug,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )
+    debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)
-        print,
+    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
     required TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )
+    error,
     required TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )
+    testDone,
     required TResult Function(int time, bool? success) done,
     required TResult Function(int time) unknown,
-  }) =>
-      throw _privateConstructorUsedError;
+  }) => throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)?
-        start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)?
-        debug,
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)?
-        print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)?
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )?
+    error,
     TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)?
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )?
+    testDone,
     TResult Function(int time, bool? success)? done,
     TResult Function(int time)? unknown,
-  }) =>
-      throw _privateConstructorUsedError;
+  }) => throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)?
-        start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)?
-        debug,
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)?
-        print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)?
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )?
+    error,
     TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)?
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )?
+    testDone,
     TResult Function(int time, bool? success)? done,
     TResult Function(int time)? unknown,
     required TResult orElse(),
-  }) =>
-      throw _privateConstructorUsedError;
+  }) => throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
     required TResult Function(_Start value) start,
@@ -159,8 +153,7 @@ mixin _$Event {
     required TResult Function(_TestDone value) testDone,
     required TResult Function(_Done value) done,
     required TResult Function(_Unknown value) unknown,
-  }) =>
-      throw _privateConstructorUsedError;
+  }) => throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
     TResult Function(_Start value)? start,
@@ -174,8 +167,7 @@ mixin _$Event {
     TResult Function(_TestDone value)? testDone,
     TResult Function(_Done value)? done,
     TResult Function(_Unknown value)? unknown,
-  }) =>
-      throw _privateConstructorUsedError;
+  }) => throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
     TResult Function(_Start value)? start,
@@ -190,8 +182,7 @@ mixin _$Event {
     TResult Function(_Done value)? done,
     TResult Function(_Unknown value)? unknown,
     required TResult orElse(),
-  }) =>
-      throw _privateConstructorUsedError;
+  }) => throw _privateConstructorUsedError;
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
   $EventCopyWith<Event> get copyWith => throw _privateConstructorUsedError;
@@ -199,8 +190,7 @@ mixin _$Event {
 
 /// @nodoc
 abstract class $EventCopyWith<$Res> {
-  factory $EventCopyWith(Event value, $Res Function(Event) then) =
-      _$EventCopyWithImpl<$Res>;
+  factory $EventCopyWith(Event value, $Res Function(Event) then) = _$EventCopyWithImpl<$Res>;
   $Res call({int time});
 }
 
@@ -213,31 +203,29 @@ class _$EventCopyWithImpl<$Res> implements $EventCopyWith<$Res> {
   final $Res Function(Event) _then;
 
   @override
-  $Res call({
-    Object? time = freezed,
-  }) {
-    return _then(_value.copyWith(
-      time: time == freezed
-          ? _value.time
-          : time // ignore: cast_nullable_to_non_nullable
-              as int,
-    ));
+  $Res call({Object? time = freezed}) {
+    return _then(
+      _value.copyWith(
+        time:
+            time == freezed
+                ? _value.time
+                : time // ignore: cast_nullable_to_non_nullable
+                    as int,
+      ),
+    );
   }
 }
 
 /// @nodoc
 abstract class _$$_StartCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$_StartCopyWith(_$_Start value, $Res Function(_$_Start) then) =
-      __$$_StartCopyWithImpl<$Res>;
+  factory _$$_StartCopyWith(_$_Start value, $Res Function(_$_Start) then) = __$$_StartCopyWithImpl<$Res>;
   @override
   $Res call({int time, String protocolVersion, String? runnerVersion, int pid});
 }
 
 /// @nodoc
-class __$$_StartCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res>
-    implements _$$_StartCopyWith<$Res> {
-  __$$_StartCopyWithImpl(_$_Start _value, $Res Function(_$_Start) _then)
-      : super(_value, (v) => _then(v as _$_Start));
+class __$$_StartCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> implements _$$_StartCopyWith<$Res> {
+  __$$_StartCopyWithImpl(_$_Start _value, $Res Function(_$_Start) _then) : super(_value, (v) => _then(v as _$_Start));
 
   @override
   _$_Start get _value => super._value as _$_Start;
@@ -249,40 +237,45 @@ class __$$_StartCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res>
     Object? runnerVersion = freezed,
     Object? pid = freezed,
   }) {
-    return _then(_$_Start(
-      time: time == freezed
-          ? _value.time
-          : time // ignore: cast_nullable_to_non_nullable
-              as int,
-      protocolVersion: protocolVersion == freezed
-          ? _value.protocolVersion
-          : protocolVersion // ignore: cast_nullable_to_non_nullable
-              as String,
-      runnerVersion: runnerVersion == freezed
-          ? _value.runnerVersion
-          : runnerVersion // ignore: cast_nullable_to_non_nullable
-              as String?,
-      pid: pid == freezed
-          ? _value.pid
-          : pid // ignore: cast_nullable_to_non_nullable
-              as int,
-    ));
+    return _then(
+      _$_Start(
+        time:
+            time == freezed
+                ? _value.time
+                : time // ignore: cast_nullable_to_non_nullable
+                    as int,
+        protocolVersion:
+            protocolVersion == freezed
+                ? _value.protocolVersion
+                : protocolVersion // ignore: cast_nullable_to_non_nullable
+                    as String,
+        runnerVersion:
+            runnerVersion == freezed
+                ? _value.runnerVersion
+                : runnerVersion // ignore: cast_nullable_to_non_nullable
+                    as String?,
+        pid:
+            pid == freezed
+                ? _value.pid
+                : pid // ignore: cast_nullable_to_non_nullable
+                    as int,
+      ),
+    );
   }
 }
 
 /// @nodoc
 @JsonSerializable()
 class _$_Start implements _Start {
-  const _$_Start(
-      {required this.time,
-      required this.protocolVersion,
-      this.runnerVersion,
-      required this.pid,
-      final String? $type})
-      : $type = $type ?? 'start';
+  const _$_Start({
+    required this.time,
+    required this.protocolVersion,
+    this.runnerVersion,
+    required this.pid,
+    final String? $type,
+  }) : $type = $type ?? 'start';
 
-  factory _$_Start.fromJson(Map<String, dynamic> json) =>
-      _$$_StartFromJson(json);
+  factory _$_Start.fromJson(Map<String, dynamic> json) => _$$_StartFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -319,57 +312,57 @@ class _$_Start implements _Start {
         (other.runtimeType == runtimeType &&
             other is _$_Start &&
             const DeepCollectionEquality().equals(other.time, time) &&
-            const DeepCollectionEquality()
-                .equals(other.protocolVersion, protocolVersion) &&
-            const DeepCollectionEquality()
-                .equals(other.runnerVersion, runnerVersion) &&
+            const DeepCollectionEquality().equals(other.protocolVersion, protocolVersion) &&
+            const DeepCollectionEquality().equals(other.runnerVersion, runnerVersion) &&
             const DeepCollectionEquality().equals(other.pid, pid));
   }
 
   @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(time),
-      const DeepCollectionEquality().hash(protocolVersion),
-      const DeepCollectionEquality().hash(runnerVersion),
-      const DeepCollectionEquality().hash(pid));
+    runtimeType,
+    const DeepCollectionEquality().hash(time),
+    const DeepCollectionEquality().hash(protocolVersion),
+    const DeepCollectionEquality().hash(runnerVersion),
+    const DeepCollectionEquality().hash(pid),
+  );
 
   @JsonKey(ignore: true)
   @override
-  _$$_StartCopyWith<_$_Start> get copyWith =>
-      __$$_StartCopyWithImpl<_$_Start>(this, _$identity);
+  _$$_StartCopyWith<_$_Start> get copyWith => __$$_StartCopyWithImpl<_$_Start>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)
-        start,
+    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
-    required TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)
-        debug,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )
+    debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)
-        print,
+    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
     required TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )
+    error,
     required TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )
+    testDone,
     required TResult Function(int time, bool? success) done,
     required TResult Function(int time) unknown,
   }) {
@@ -379,33 +372,30 @@ class _$_Start implements _Start {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)?
-        start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)?
-        debug,
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)?
-        print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)?
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )?
+    error,
     TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)?
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )?
+    testDone,
     TResult Function(int time, bool? success)? done,
     TResult Function(int time)? unknown,
   }) {
@@ -415,33 +405,30 @@ class _$_Start implements _Start {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)?
-        start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)?
-        debug,
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)?
-        print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)?
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )?
+    error,
     TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)?
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )?
+    testDone,
     TResult Function(int time, bool? success)? done,
     TResult Function(int time)? unknown,
     required TResult orElse(),
@@ -512,23 +499,21 @@ class _$_Start implements _Start {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_StartToJson(
-      this,
-    );
+    return _$$_StartToJson(this);
   }
 }
 
 abstract class _Start implements Event {
-  const factory _Start(
-      {required final int time,
-      required final String protocolVersion,
-      final String? runnerVersion,
-      required final int pid}) = _$_Start;
+  const factory _Start({
+    required final int time,
+    required final String protocolVersion,
+    final String? runnerVersion,
+    required final int pid,
+  }) = _$_Start;
 
   factory _Start.fromJson(Map<String, dynamic> json) = _$_Start.fromJson;
 
   @override
-
   /// The time (in milliseconds) that has elapsed since the test runner started.
   int get time;
 
@@ -547,56 +532,50 @@ abstract class _Start implements Event {
   int get pid;
   @override
   @JsonKey(ignore: true)
-  _$$_StartCopyWith<_$_Start> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$_StartCopyWith<_$_Start> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$_AllSuitesCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$_AllSuitesCopyWith(
-          _$_AllSuites value, $Res Function(_$_AllSuites) then) =
+  factory _$$_AllSuitesCopyWith(_$_AllSuites value, $Res Function(_$_AllSuites) then) =
       __$$_AllSuitesCopyWithImpl<$Res>;
   @override
   $Res call({int time, int count});
 }
 
 /// @nodoc
-class __$$_AllSuitesCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res>
-    implements _$$_AllSuitesCopyWith<$Res> {
-  __$$_AllSuitesCopyWithImpl(
-      _$_AllSuites _value, $Res Function(_$_AllSuites) _then)
-      : super(_value, (v) => _then(v as _$_AllSuites));
+class __$$_AllSuitesCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> implements _$$_AllSuitesCopyWith<$Res> {
+  __$$_AllSuitesCopyWithImpl(_$_AllSuites _value, $Res Function(_$_AllSuites) _then)
+    : super(_value, (v) => _then(v as _$_AllSuites));
 
   @override
   _$_AllSuites get _value => super._value as _$_AllSuites;
 
   @override
-  $Res call({
-    Object? time = freezed,
-    Object? count = freezed,
-  }) {
-    return _then(_$_AllSuites(
-      time: time == freezed
-          ? _value.time
-          : time // ignore: cast_nullable_to_non_nullable
-              as int,
-      count: count == freezed
-          ? _value.count
-          : count // ignore: cast_nullable_to_non_nullable
-              as int,
-    ));
+  $Res call({Object? time = freezed, Object? count = freezed}) {
+    return _then(
+      _$_AllSuites(
+        time:
+            time == freezed
+                ? _value.time
+                : time // ignore: cast_nullable_to_non_nullable
+                    as int,
+        count:
+            count == freezed
+                ? _value.count
+                : count // ignore: cast_nullable_to_non_nullable
+                    as int,
+      ),
+    );
   }
 }
 
 /// @nodoc
 @JsonSerializable()
 class _$_AllSuites implements _AllSuites {
-  const _$_AllSuites(
-      {required this.time, required this.count, final String? $type})
-      : $type = $type ?? 'allSuites';
+  const _$_AllSuites({required this.time, required this.count, final String? $type}) : $type = $type ?? 'allSuites';
 
-  factory _$_AllSuites.fromJson(Map<String, dynamic> json) =>
-      _$$_AllSuitesFromJson(json);
+  factory _$_AllSuites.fromJson(Map<String, dynamic> json) => _$$_AllSuitesFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -625,46 +604,45 @@ class _$_AllSuites implements _AllSuites {
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(time),
-      const DeepCollectionEquality().hash(count));
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(time), const DeepCollectionEquality().hash(count));
 
   @JsonKey(ignore: true)
   @override
-  _$$_AllSuitesCopyWith<_$_AllSuites> get copyWith =>
-      __$$_AllSuitesCopyWithImpl<_$_AllSuites>(this, _$identity);
+  _$$_AllSuitesCopyWith<_$_AllSuites> get copyWith => __$$_AllSuitesCopyWithImpl<_$_AllSuites>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)
-        start,
+    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
-    required TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)
-        debug,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )
+    debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)
-        print,
+    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
     required TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )
+    error,
     required TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )
+    testDone,
     required TResult Function(int time, bool? success) done,
     required TResult Function(int time) unknown,
   }) {
@@ -674,33 +652,30 @@ class _$_AllSuites implements _AllSuites {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)?
-        start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)?
-        debug,
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)?
-        print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)?
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )?
+    error,
     TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)?
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )?
+    testDone,
     TResult Function(int time, bool? success)? done,
     TResult Function(int time)? unknown,
   }) {
@@ -710,33 +685,30 @@ class _$_AllSuites implements _AllSuites {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)?
-        start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)?
-        debug,
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)?
-        print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)?
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )?
+    error,
     TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)?
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )?
+    testDone,
     TResult Function(int time, bool? success)? done,
     TResult Function(int time)? unknown,
     required TResult orElse(),
@@ -807,21 +779,16 @@ class _$_AllSuites implements _AllSuites {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_AllSuitesToJson(
-      this,
-    );
+    return _$$_AllSuitesToJson(this);
   }
 }
 
 abstract class _AllSuites implements Event {
-  const factory _AllSuites(
-      {required final int time, required final int count}) = _$_AllSuites;
+  const factory _AllSuites({required final int time, required final int count}) = _$_AllSuites;
 
-  factory _AllSuites.fromJson(Map<String, dynamic> json) =
-      _$_AllSuites.fromJson;
+  factory _AllSuites.fromJson(Map<String, dynamic> json) = _$_AllSuites.fromJson;
 
   @override
-
   /// The time (in milliseconds) that has elapsed since the test runner started.
   int get time;
 
@@ -829,14 +796,12 @@ abstract class _AllSuites implements Event {
   int get count;
   @override
   @JsonKey(ignore: true)
-  _$$_AllSuitesCopyWith<_$_AllSuites> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$_AllSuitesCopyWith<_$_AllSuites> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$_SuiteCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$_SuiteCopyWith(_$_Suite value, $Res Function(_$_Suite) then) =
-      __$$_SuiteCopyWithImpl<$Res>;
+  factory _$$_SuiteCopyWith(_$_Suite value, $Res Function(_$_Suite) then) = __$$_SuiteCopyWithImpl<$Res>;
   @override
   $Res call({int time, Suite suite});
 
@@ -844,29 +809,28 @@ abstract class _$$_SuiteCopyWith<$Res> implements $EventCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_SuiteCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res>
-    implements _$$_SuiteCopyWith<$Res> {
-  __$$_SuiteCopyWithImpl(_$_Suite _value, $Res Function(_$_Suite) _then)
-      : super(_value, (v) => _then(v as _$_Suite));
+class __$$_SuiteCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> implements _$$_SuiteCopyWith<$Res> {
+  __$$_SuiteCopyWithImpl(_$_Suite _value, $Res Function(_$_Suite) _then) : super(_value, (v) => _then(v as _$_Suite));
 
   @override
   _$_Suite get _value => super._value as _$_Suite;
 
   @override
-  $Res call({
-    Object? time = freezed,
-    Object? suite = freezed,
-  }) {
-    return _then(_$_Suite(
-      time: time == freezed
-          ? _value.time
-          : time // ignore: cast_nullable_to_non_nullable
-              as int,
-      suite: suite == freezed
-          ? _value.suite
-          : suite // ignore: cast_nullable_to_non_nullable
-              as Suite,
-    ));
+  $Res call({Object? time = freezed, Object? suite = freezed}) {
+    return _then(
+      _$_Suite(
+        time:
+            time == freezed
+                ? _value.time
+                : time // ignore: cast_nullable_to_non_nullable
+                    as int,
+        suite:
+            suite == freezed
+                ? _value.suite
+                : suite // ignore: cast_nullable_to_non_nullable
+                    as Suite,
+      ),
+    );
   }
 
   @override
@@ -880,11 +844,9 @@ class __$$_SuiteCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res>
 /// @nodoc
 @JsonSerializable()
 class _$_Suite implements _Suite {
-  const _$_Suite({required this.time, required this.suite, final String? $type})
-      : $type = $type ?? 'suite';
+  const _$_Suite({required this.time, required this.suite, final String? $type}) : $type = $type ?? 'suite';
 
-  factory _$_Suite.fromJson(Map<String, dynamic> json) =>
-      _$$_SuiteFromJson(json);
+  factory _$_Suite.fromJson(Map<String, dynamic> json) => _$$_SuiteFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -913,46 +875,45 @@ class _$_Suite implements _Suite {
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(time),
-      const DeepCollectionEquality().hash(suite));
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(time), const DeepCollectionEquality().hash(suite));
 
   @JsonKey(ignore: true)
   @override
-  _$$_SuiteCopyWith<_$_Suite> get copyWith =>
-      __$$_SuiteCopyWithImpl<_$_Suite>(this, _$identity);
+  _$$_SuiteCopyWith<_$_Suite> get copyWith => __$$_SuiteCopyWithImpl<_$_Suite>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)
-        start,
+    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
-    required TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)
-        debug,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )
+    debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)
-        print,
+    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
     required TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )
+    error,
     required TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )
+    testDone,
     required TResult Function(int time, bool? success) done,
     required TResult Function(int time) unknown,
   }) {
@@ -962,33 +923,30 @@ class _$_Suite implements _Suite {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)?
-        start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)?
-        debug,
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)?
-        print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)?
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )?
+    error,
     TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)?
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )?
+    testDone,
     TResult Function(int time, bool? success)? done,
     TResult Function(int time)? unknown,
   }) {
@@ -998,33 +956,30 @@ class _$_Suite implements _Suite {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)?
-        start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)?
-        debug,
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)?
-        print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)?
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )?
+    error,
     TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)?
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )?
+    testDone,
     TResult Function(int time, bool? success)? done,
     TResult Function(int time)? unknown,
     required TResult orElse(),
@@ -1095,20 +1050,16 @@ class _$_Suite implements _Suite {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_SuiteToJson(
-      this,
-    );
+    return _$$_SuiteToJson(this);
   }
 }
 
 abstract class _Suite implements Event {
-  const factory _Suite({required final int time, required final Suite suite}) =
-      _$_Suite;
+  const factory _Suite({required final int time, required final Suite suite}) = _$_Suite;
 
   factory _Suite.fromJson(Map<String, dynamic> json) = _$_Suite.fromJson;
 
   @override
-
   /// The time (in milliseconds) that has elapsed since the test runner started.
   int get time;
 
@@ -1116,27 +1067,19 @@ abstract class _Suite implements Event {
   Suite get suite;
   @override
   @JsonKey(ignore: true)
-  _$$_SuiteCopyWith<_$_Suite> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$_SuiteCopyWith<_$_Suite> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$_DebugCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$_DebugCopyWith(_$_Debug value, $Res Function(_$_Debug) then) =
-      __$$_DebugCopyWithImpl<$Res>;
+  factory _$$_DebugCopyWith(_$_Debug value, $Res Function(_$_Debug) then) = __$$_DebugCopyWithImpl<$Res>;
   @override
-  $Res call(
-      {int time,
-      @JsonKey(name: 'suiteID') int suiteId,
-      String? observatory,
-      String? remoteDebugger});
+  $Res call({int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger});
 }
 
 /// @nodoc
-class __$$_DebugCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res>
-    implements _$$_DebugCopyWith<$Res> {
-  __$$_DebugCopyWithImpl(_$_Debug _value, $Res Function(_$_Debug) _then)
-      : super(_value, (v) => _then(v as _$_Debug));
+class __$$_DebugCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> implements _$$_DebugCopyWith<$Res> {
+  __$$_DebugCopyWithImpl(_$_Debug _value, $Res Function(_$_Debug) _then) : super(_value, (v) => _then(v as _$_Debug));
 
   @override
   _$_Debug get _value => super._value as _$_Debug;
@@ -1148,40 +1091,45 @@ class __$$_DebugCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res>
     Object? observatory = freezed,
     Object? remoteDebugger = freezed,
   }) {
-    return _then(_$_Debug(
-      time: time == freezed
-          ? _value.time
-          : time // ignore: cast_nullable_to_non_nullable
-              as int,
-      suiteId: suiteId == freezed
-          ? _value.suiteId
-          : suiteId // ignore: cast_nullable_to_non_nullable
-              as int,
-      observatory: observatory == freezed
-          ? _value.observatory
-          : observatory // ignore: cast_nullable_to_non_nullable
-              as String?,
-      remoteDebugger: remoteDebugger == freezed
-          ? _value.remoteDebugger
-          : remoteDebugger // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
+    return _then(
+      _$_Debug(
+        time:
+            time == freezed
+                ? _value.time
+                : time // ignore: cast_nullable_to_non_nullable
+                    as int,
+        suiteId:
+            suiteId == freezed
+                ? _value.suiteId
+                : suiteId // ignore: cast_nullable_to_non_nullable
+                    as int,
+        observatory:
+            observatory == freezed
+                ? _value.observatory
+                : observatory // ignore: cast_nullable_to_non_nullable
+                    as String?,
+        remoteDebugger:
+            remoteDebugger == freezed
+                ? _value.remoteDebugger
+                : remoteDebugger // ignore: cast_nullable_to_non_nullable
+                    as String?,
+      ),
+    );
   }
 }
 
 /// @nodoc
 @JsonSerializable()
 class _$_Debug implements _Debug {
-  const _$_Debug(
-      {required this.time,
-      @JsonKey(name: 'suiteID') required this.suiteId,
-      this.observatory,
-      this.remoteDebugger,
-      final String? $type})
-      : $type = $type ?? 'debug';
+  const _$_Debug({
+    required this.time,
+    @JsonKey(name: 'suiteID') required this.suiteId,
+    this.observatory,
+    this.remoteDebugger,
+    final String? $type,
+  }) : $type = $type ?? 'debug';
 
-  factory _$_Debug.fromJson(Map<String, dynamic> json) =>
-      _$$_DebugFromJson(json);
+  factory _$_Debug.fromJson(Map<String, dynamic> json) => _$$_DebugFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -1215,56 +1163,56 @@ class _$_Debug implements _Debug {
             other is _$_Debug &&
             const DeepCollectionEquality().equals(other.time, time) &&
             const DeepCollectionEquality().equals(other.suiteId, suiteId) &&
-            const DeepCollectionEquality()
-                .equals(other.observatory, observatory) &&
-            const DeepCollectionEquality()
-                .equals(other.remoteDebugger, remoteDebugger));
+            const DeepCollectionEquality().equals(other.observatory, observatory) &&
+            const DeepCollectionEquality().equals(other.remoteDebugger, remoteDebugger));
   }
 
   @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(time),
-      const DeepCollectionEquality().hash(suiteId),
-      const DeepCollectionEquality().hash(observatory),
-      const DeepCollectionEquality().hash(remoteDebugger));
+    runtimeType,
+    const DeepCollectionEquality().hash(time),
+    const DeepCollectionEquality().hash(suiteId),
+    const DeepCollectionEquality().hash(observatory),
+    const DeepCollectionEquality().hash(remoteDebugger),
+  );
 
   @JsonKey(ignore: true)
   @override
-  _$$_DebugCopyWith<_$_Debug> get copyWith =>
-      __$$_DebugCopyWithImpl<_$_Debug>(this, _$identity);
+  _$$_DebugCopyWith<_$_Debug> get copyWith => __$$_DebugCopyWithImpl<_$_Debug>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)
-        start,
+    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
-    required TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)
-        debug,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )
+    debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)
-        print,
+    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
     required TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )
+    error,
     required TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )
+    testDone,
     required TResult Function(int time, bool? success) done,
     required TResult Function(int time) unknown,
   }) {
@@ -1274,33 +1222,30 @@ class _$_Debug implements _Debug {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)?
-        start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)?
-        debug,
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)?
-        print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)?
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )?
+    error,
     TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)?
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )?
+    testDone,
     TResult Function(int time, bool? success)? done,
     TResult Function(int time)? unknown,
   }) {
@@ -1310,33 +1255,30 @@ class _$_Debug implements _Debug {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)?
-        start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)?
-        debug,
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)?
-        print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)?
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )?
+    error,
     TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)?
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )?
+    testDone,
     TResult Function(int time, bool? success)? done,
     TResult Function(int time)? unknown,
     required TResult orElse(),
@@ -1407,23 +1349,21 @@ class _$_Debug implements _Debug {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_DebugToJson(
-      this,
-    );
+    return _$$_DebugToJson(this);
   }
 }
 
 abstract class _Debug implements Event {
-  const factory _Debug(
-      {required final int time,
-      @JsonKey(name: 'suiteID') required final int suiteId,
-      final String? observatory,
-      final String? remoteDebugger}) = _$_Debug;
+  const factory _Debug({
+    required final int time,
+    @JsonKey(name: 'suiteID') required final int suiteId,
+    final String? observatory,
+    final String? remoteDebugger,
+  }) = _$_Debug;
 
   factory _Debug.fromJson(Map<String, dynamic> json) = _$_Debug.fromJson;
 
   @override
-
   /// The time (in milliseconds) that has elapsed since the test runner started.
   int get time;
 
@@ -1438,14 +1378,12 @@ abstract class _Debug implements Event {
   String? get remoteDebugger;
   @override
   @JsonKey(ignore: true)
-  _$$_DebugCopyWith<_$_Debug> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$_DebugCopyWith<_$_Debug> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$_GroupCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$_GroupCopyWith(_$_Group value, $Res Function(_$_Group) then) =
-      __$$_GroupCopyWithImpl<$Res>;
+  factory _$$_GroupCopyWith(_$_Group value, $Res Function(_$_Group) then) = __$$_GroupCopyWithImpl<$Res>;
   @override
   $Res call({int time, Group group});
 
@@ -1453,29 +1391,28 @@ abstract class _$$_GroupCopyWith<$Res> implements $EventCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_GroupCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res>
-    implements _$$_GroupCopyWith<$Res> {
-  __$$_GroupCopyWithImpl(_$_Group _value, $Res Function(_$_Group) _then)
-      : super(_value, (v) => _then(v as _$_Group));
+class __$$_GroupCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> implements _$$_GroupCopyWith<$Res> {
+  __$$_GroupCopyWithImpl(_$_Group _value, $Res Function(_$_Group) _then) : super(_value, (v) => _then(v as _$_Group));
 
   @override
   _$_Group get _value => super._value as _$_Group;
 
   @override
-  $Res call({
-    Object? time = freezed,
-    Object? group = freezed,
-  }) {
-    return _then(_$_Group(
-      time: time == freezed
-          ? _value.time
-          : time // ignore: cast_nullable_to_non_nullable
-              as int,
-      group: group == freezed
-          ? _value.group
-          : group // ignore: cast_nullable_to_non_nullable
-              as Group,
-    ));
+  $Res call({Object? time = freezed, Object? group = freezed}) {
+    return _then(
+      _$_Group(
+        time:
+            time == freezed
+                ? _value.time
+                : time // ignore: cast_nullable_to_non_nullable
+                    as int,
+        group:
+            group == freezed
+                ? _value.group
+                : group // ignore: cast_nullable_to_non_nullable
+                    as Group,
+      ),
+    );
   }
 
   @override
@@ -1489,11 +1426,9 @@ class __$$_GroupCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res>
 /// @nodoc
 @JsonSerializable()
 class _$_Group implements _Group {
-  const _$_Group({required this.time, required this.group, final String? $type})
-      : $type = $type ?? 'group';
+  const _$_Group({required this.time, required this.group, final String? $type}) : $type = $type ?? 'group';
 
-  factory _$_Group.fromJson(Map<String, dynamic> json) =>
-      _$$_GroupFromJson(json);
+  factory _$_Group.fromJson(Map<String, dynamic> json) => _$$_GroupFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -1522,46 +1457,45 @@ class _$_Group implements _Group {
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(time),
-      const DeepCollectionEquality().hash(group));
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(time), const DeepCollectionEquality().hash(group));
 
   @JsonKey(ignore: true)
   @override
-  _$$_GroupCopyWith<_$_Group> get copyWith =>
-      __$$_GroupCopyWithImpl<_$_Group>(this, _$identity);
+  _$$_GroupCopyWith<_$_Group> get copyWith => __$$_GroupCopyWithImpl<_$_Group>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)
-        start,
+    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
-    required TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)
-        debug,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )
+    debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)
-        print,
+    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
     required TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )
+    error,
     required TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )
+    testDone,
     required TResult Function(int time, bool? success) done,
     required TResult Function(int time) unknown,
   }) {
@@ -1571,33 +1505,30 @@ class _$_Group implements _Group {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)?
-        start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)?
-        debug,
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)?
-        print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)?
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )?
+    error,
     TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)?
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )?
+    testDone,
     TResult Function(int time, bool? success)? done,
     TResult Function(int time)? unknown,
   }) {
@@ -1607,33 +1538,30 @@ class _$_Group implements _Group {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)?
-        start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)?
-        debug,
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)?
-        print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)?
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )?
+    error,
     TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)?
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )?
+    testDone,
     TResult Function(int time, bool? success)? done,
     TResult Function(int time)? unknown,
     required TResult orElse(),
@@ -1704,20 +1632,16 @@ class _$_Group implements _Group {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GroupToJson(
-      this,
-    );
+    return _$$_GroupToJson(this);
   }
 }
 
 abstract class _Group implements Event {
-  const factory _Group({required final int time, required final Group group}) =
-      _$_Group;
+  const factory _Group({required final int time, required final Group group}) = _$_Group;
 
   factory _Group.fromJson(Map<String, dynamic> json) = _$_Group.fromJson;
 
   @override
-
   /// The time (in milliseconds) that has elapsed since the test runner started.
   int get time;
 
@@ -1725,14 +1649,12 @@ abstract class _Group implements Event {
   Group get group;
   @override
   @JsonKey(ignore: true)
-  _$$_GroupCopyWith<_$_Group> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$_GroupCopyWith<_$_Group> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$_TestStartCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$_TestStartCopyWith(
-          _$_TestStart value, $Res Function(_$_TestStart) then) =
+  factory _$$_TestStartCopyWith(_$_TestStart value, $Res Function(_$_TestStart) then) =
       __$$_TestStartCopyWithImpl<$Res>;
   @override
   $Res call({int time, Test test});
@@ -1741,30 +1663,29 @@ abstract class _$$_TestStartCopyWith<$Res> implements $EventCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_TestStartCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res>
-    implements _$$_TestStartCopyWith<$Res> {
-  __$$_TestStartCopyWithImpl(
-      _$_TestStart _value, $Res Function(_$_TestStart) _then)
-      : super(_value, (v) => _then(v as _$_TestStart));
+class __$$_TestStartCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> implements _$$_TestStartCopyWith<$Res> {
+  __$$_TestStartCopyWithImpl(_$_TestStart _value, $Res Function(_$_TestStart) _then)
+    : super(_value, (v) => _then(v as _$_TestStart));
 
   @override
   _$_TestStart get _value => super._value as _$_TestStart;
 
   @override
-  $Res call({
-    Object? time = freezed,
-    Object? test = freezed,
-  }) {
-    return _then(_$_TestStart(
-      time: time == freezed
-          ? _value.time
-          : time // ignore: cast_nullable_to_non_nullable
-              as int,
-      test: test == freezed
-          ? _value.test
-          : test // ignore: cast_nullable_to_non_nullable
-              as Test,
-    ));
+  $Res call({Object? time = freezed, Object? test = freezed}) {
+    return _then(
+      _$_TestStart(
+        time:
+            time == freezed
+                ? _value.time
+                : time // ignore: cast_nullable_to_non_nullable
+                    as int,
+        test:
+            test == freezed
+                ? _value.test
+                : test // ignore: cast_nullable_to_non_nullable
+                    as Test,
+      ),
+    );
   }
 
   @override
@@ -1778,12 +1699,9 @@ class __$$_TestStartCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res>
 /// @nodoc
 @JsonSerializable()
 class _$_TestStart implements _TestStart {
-  const _$_TestStart(
-      {required this.time, required this.test, final String? $type})
-      : $type = $type ?? 'testStart';
+  const _$_TestStart({required this.time, required this.test, final String? $type}) : $type = $type ?? 'testStart';
 
-  factory _$_TestStart.fromJson(Map<String, dynamic> json) =>
-      _$$_TestStartFromJson(json);
+  factory _$_TestStart.fromJson(Map<String, dynamic> json) => _$$_TestStartFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -1812,46 +1730,45 @@ class _$_TestStart implements _TestStart {
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(time),
-      const DeepCollectionEquality().hash(test));
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(time), const DeepCollectionEquality().hash(test));
 
   @JsonKey(ignore: true)
   @override
-  _$$_TestStartCopyWith<_$_TestStart> get copyWith =>
-      __$$_TestStartCopyWithImpl<_$_TestStart>(this, _$identity);
+  _$$_TestStartCopyWith<_$_TestStart> get copyWith => __$$_TestStartCopyWithImpl<_$_TestStart>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)
-        start,
+    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
-    required TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)
-        debug,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )
+    debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)
-        print,
+    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
     required TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )
+    error,
     required TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )
+    testDone,
     required TResult Function(int time, bool? success) done,
     required TResult Function(int time) unknown,
   }) {
@@ -1861,33 +1778,30 @@ class _$_TestStart implements _TestStart {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)?
-        start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)?
-        debug,
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)?
-        print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)?
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )?
+    error,
     TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)?
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )?
+    testDone,
     TResult Function(int time, bool? success)? done,
     TResult Function(int time)? unknown,
   }) {
@@ -1897,33 +1811,30 @@ class _$_TestStart implements _TestStart {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)?
-        start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)?
-        debug,
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)?
-        print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)?
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )?
+    error,
     TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)?
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )?
+    testDone,
     TResult Function(int time, bool? success)? done,
     TResult Function(int time)? unknown,
     required TResult orElse(),
@@ -1994,21 +1905,16 @@ class _$_TestStart implements _TestStart {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_TestStartToJson(
-      this,
-    );
+    return _$$_TestStartToJson(this);
   }
 }
 
 abstract class _TestStart implements Event {
-  const factory _TestStart(
-      {required final int time, required final Test test}) = _$_TestStart;
+  const factory _TestStart({required final int time, required final Test test}) = _$_TestStart;
 
-  factory _TestStart.fromJson(Map<String, dynamic> json) =
-      _$_TestStart.fromJson;
+  factory _TestStart.fromJson(Map<String, dynamic> json) = _$_TestStart.fromJson;
 
   @override
-
   /// The time (in milliseconds) that has elapsed since the test runner started.
   int get time;
 
@@ -2016,27 +1922,19 @@ abstract class _TestStart implements Event {
   Test get test;
   @override
   @JsonKey(ignore: true)
-  _$$_TestStartCopyWith<_$_TestStart> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$_TestStartCopyWith<_$_TestStart> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$_PrintCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$_PrintCopyWith(_$_Print value, $Res Function(_$_Print) then) =
-      __$$_PrintCopyWithImpl<$Res>;
+  factory _$$_PrintCopyWith(_$_Print value, $Res Function(_$_Print) then) = __$$_PrintCopyWithImpl<$Res>;
   @override
-  $Res call(
-      {int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message});
+  $Res call({int time, @JsonKey(name: 'testID') int testId, String messageType, String message});
 }
 
 /// @nodoc
-class __$$_PrintCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res>
-    implements _$$_PrintCopyWith<$Res> {
-  __$$_PrintCopyWithImpl(_$_Print _value, $Res Function(_$_Print) _then)
-      : super(_value, (v) => _then(v as _$_Print));
+class __$$_PrintCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> implements _$$_PrintCopyWith<$Res> {
+  __$$_PrintCopyWithImpl(_$_Print _value, $Res Function(_$_Print) _then) : super(_value, (v) => _then(v as _$_Print));
 
   @override
   _$_Print get _value => super._value as _$_Print;
@@ -2048,40 +1946,45 @@ class __$$_PrintCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res>
     Object? messageType = freezed,
     Object? message = freezed,
   }) {
-    return _then(_$_Print(
-      time: time == freezed
-          ? _value.time
-          : time // ignore: cast_nullable_to_non_nullable
-              as int,
-      testId: testId == freezed
-          ? _value.testId
-          : testId // ignore: cast_nullable_to_non_nullable
-              as int,
-      messageType: messageType == freezed
-          ? _value.messageType
-          : messageType // ignore: cast_nullable_to_non_nullable
-              as String,
-      message: message == freezed
-          ? _value.message
-          : message // ignore: cast_nullable_to_non_nullable
-              as String,
-    ));
+    return _then(
+      _$_Print(
+        time:
+            time == freezed
+                ? _value.time
+                : time // ignore: cast_nullable_to_non_nullable
+                    as int,
+        testId:
+            testId == freezed
+                ? _value.testId
+                : testId // ignore: cast_nullable_to_non_nullable
+                    as int,
+        messageType:
+            messageType == freezed
+                ? _value.messageType
+                : messageType // ignore: cast_nullable_to_non_nullable
+                    as String,
+        message:
+            message == freezed
+                ? _value.message
+                : message // ignore: cast_nullable_to_non_nullable
+                    as String,
+      ),
+    );
   }
 }
 
 /// @nodoc
 @JsonSerializable()
 class _$_Print implements _Print {
-  const _$_Print(
-      {required this.time,
-      @JsonKey(name: 'testID') required this.testId,
-      required this.messageType,
-      required this.message,
-      final String? $type})
-      : $type = $type ?? 'print';
+  const _$_Print({
+    required this.time,
+    @JsonKey(name: 'testID') required this.testId,
+    required this.messageType,
+    required this.message,
+    final String? $type,
+  }) : $type = $type ?? 'print';
 
-  factory _$_Print.fromJson(Map<String, dynamic> json) =>
-      _$$_PrintFromJson(json);
+  factory _$_Print.fromJson(Map<String, dynamic> json) => _$$_PrintFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -2115,55 +2018,56 @@ class _$_Print implements _Print {
             other is _$_Print &&
             const DeepCollectionEquality().equals(other.time, time) &&
             const DeepCollectionEquality().equals(other.testId, testId) &&
-            const DeepCollectionEquality()
-                .equals(other.messageType, messageType) &&
+            const DeepCollectionEquality().equals(other.messageType, messageType) &&
             const DeepCollectionEquality().equals(other.message, message));
   }
 
   @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(time),
-      const DeepCollectionEquality().hash(testId),
-      const DeepCollectionEquality().hash(messageType),
-      const DeepCollectionEquality().hash(message));
+    runtimeType,
+    const DeepCollectionEquality().hash(time),
+    const DeepCollectionEquality().hash(testId),
+    const DeepCollectionEquality().hash(messageType),
+    const DeepCollectionEquality().hash(message),
+  );
 
   @JsonKey(ignore: true)
   @override
-  _$$_PrintCopyWith<_$_Print> get copyWith =>
-      __$$_PrintCopyWithImpl<_$_Print>(this, _$identity);
+  _$$_PrintCopyWith<_$_Print> get copyWith => __$$_PrintCopyWithImpl<_$_Print>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)
-        start,
+    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
-    required TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)
-        debug,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )
+    debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)
-        print,
+    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
     required TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )
+    error,
     required TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )
+    testDone,
     required TResult Function(int time, bool? success) done,
     required TResult Function(int time) unknown,
   }) {
@@ -2173,33 +2077,30 @@ class _$_Print implements _Print {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)?
-        start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)?
-        debug,
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)?
-        print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)?
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )?
+    error,
     TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)?
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )?
+    testDone,
     TResult Function(int time, bool? success)? done,
     TResult Function(int time)? unknown,
   }) {
@@ -2209,33 +2110,30 @@ class _$_Print implements _Print {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)?
-        start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)?
-        debug,
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)?
-        print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)?
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )?
+    error,
     TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)?
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )?
+    testDone,
     TResult Function(int time, bool? success)? done,
     TResult Function(int time)? unknown,
     required TResult orElse(),
@@ -2306,23 +2204,21 @@ class _$_Print implements _Print {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PrintToJson(
-      this,
-    );
+    return _$$_PrintToJson(this);
   }
 }
 
 abstract class _Print implements Event {
-  const factory _Print(
-      {required final int time,
-      @JsonKey(name: 'testID') required final int testId,
-      required final String messageType,
-      required final String message}) = _$_Print;
+  const factory _Print({
+    required final int time,
+    @JsonKey(name: 'testID') required final int testId,
+    required final String messageType,
+    required final String message,
+  }) = _$_Print;
 
   factory _Print.fromJson(Map<String, dynamic> json) = _$_Print.fromJson;
 
   @override
-
   /// The time (in milliseconds) that has elapsed since the test runner started.
   int get time;
 
@@ -2337,28 +2233,25 @@ abstract class _Print implements Event {
   String get message;
   @override
   @JsonKey(ignore: true)
-  _$$_PrintCopyWith<_$_Print> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$_PrintCopyWith<_$_Print> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$_ErrorCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$_ErrorCopyWith(_$_Error value, $Res Function(_$_Error) then) =
-      __$$_ErrorCopyWithImpl<$Res>;
+  factory _$$_ErrorCopyWith(_$_Error value, $Res Function(_$_Error) then) = __$$_ErrorCopyWithImpl<$Res>;
   @override
-  $Res call(
-      {int time,
-      @JsonKey(name: 'testID') int testId,
-      String error,
-      @JsonKey(name: 'stackTrace') String stacktrace,
-      bool isFailure});
+  $Res call({
+    int time,
+    @JsonKey(name: 'testID') int testId,
+    String error,
+    @JsonKey(name: 'stackTrace') String stacktrace,
+    bool isFailure,
+  });
 }
 
 /// @nodoc
-class __$$_ErrorCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res>
-    implements _$$_ErrorCopyWith<$Res> {
-  __$$_ErrorCopyWithImpl(_$_Error _value, $Res Function(_$_Error) _then)
-      : super(_value, (v) => _then(v as _$_Error));
+class __$$_ErrorCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> implements _$$_ErrorCopyWith<$Res> {
+  __$$_ErrorCopyWithImpl(_$_Error _value, $Res Function(_$_Error) _then) : super(_value, (v) => _then(v as _$_Error));
 
   @override
   _$_Error get _value => super._value as _$_Error;
@@ -2371,45 +2264,51 @@ class __$$_ErrorCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res>
     Object? stacktrace = freezed,
     Object? isFailure = freezed,
   }) {
-    return _then(_$_Error(
-      time: time == freezed
-          ? _value.time
-          : time // ignore: cast_nullable_to_non_nullable
-              as int,
-      testId: testId == freezed
-          ? _value.testId
-          : testId // ignore: cast_nullable_to_non_nullable
-              as int,
-      error: error == freezed
-          ? _value.error
-          : error // ignore: cast_nullable_to_non_nullable
-              as String,
-      stacktrace: stacktrace == freezed
-          ? _value.stacktrace
-          : stacktrace // ignore: cast_nullable_to_non_nullable
-              as String,
-      isFailure: isFailure == freezed
-          ? _value.isFailure
-          : isFailure // ignore: cast_nullable_to_non_nullable
-              as bool,
-    ));
+    return _then(
+      _$_Error(
+        time:
+            time == freezed
+                ? _value.time
+                : time // ignore: cast_nullable_to_non_nullable
+                    as int,
+        testId:
+            testId == freezed
+                ? _value.testId
+                : testId // ignore: cast_nullable_to_non_nullable
+                    as int,
+        error:
+            error == freezed
+                ? _value.error
+                : error // ignore: cast_nullable_to_non_nullable
+                    as String,
+        stacktrace:
+            stacktrace == freezed
+                ? _value.stacktrace
+                : stacktrace // ignore: cast_nullable_to_non_nullable
+                    as String,
+        isFailure:
+            isFailure == freezed
+                ? _value.isFailure
+                : isFailure // ignore: cast_nullable_to_non_nullable
+                    as bool,
+      ),
+    );
   }
 }
 
 /// @nodoc
 @JsonSerializable()
 class _$_Error implements _Error {
-  const _$_Error(
-      {required this.time,
-      @JsonKey(name: 'testID') required this.testId,
-      required this.error,
-      @JsonKey(name: 'stackTrace') required this.stacktrace,
-      required this.isFailure,
-      final String? $type})
-      : $type = $type ?? 'error';
+  const _$_Error({
+    required this.time,
+    @JsonKey(name: 'testID') required this.testId,
+    required this.error,
+    @JsonKey(name: 'stackTrace') required this.stacktrace,
+    required this.isFailure,
+    final String? $type,
+  }) : $type = $type ?? 'error';
 
-  factory _$_Error.fromJson(Map<String, dynamic> json) =>
-      _$$_ErrorFromJson(json);
+  factory _$_Error.fromJson(Map<String, dynamic> json) => _$$_ErrorFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -2449,56 +2348,57 @@ class _$_Error implements _Error {
             const DeepCollectionEquality().equals(other.time, time) &&
             const DeepCollectionEquality().equals(other.testId, testId) &&
             const DeepCollectionEquality().equals(other.error, error) &&
-            const DeepCollectionEquality()
-                .equals(other.stacktrace, stacktrace) &&
+            const DeepCollectionEquality().equals(other.stacktrace, stacktrace) &&
             const DeepCollectionEquality().equals(other.isFailure, isFailure));
   }
 
   @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(time),
-      const DeepCollectionEquality().hash(testId),
-      const DeepCollectionEquality().hash(error),
-      const DeepCollectionEquality().hash(stacktrace),
-      const DeepCollectionEquality().hash(isFailure));
+    runtimeType,
+    const DeepCollectionEquality().hash(time),
+    const DeepCollectionEquality().hash(testId),
+    const DeepCollectionEquality().hash(error),
+    const DeepCollectionEquality().hash(stacktrace),
+    const DeepCollectionEquality().hash(isFailure),
+  );
 
   @JsonKey(ignore: true)
   @override
-  _$$_ErrorCopyWith<_$_Error> get copyWith =>
-      __$$_ErrorCopyWithImpl<_$_Error>(this, _$identity);
+  _$$_ErrorCopyWith<_$_Error> get copyWith => __$$_ErrorCopyWithImpl<_$_Error>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)
-        start,
+    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
-    required TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)
-        debug,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )
+    debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)
-        print,
+    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
     required TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )
+    error,
     required TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )
+    testDone,
     required TResult Function(int time, bool? success) done,
     required TResult Function(int time) unknown,
   }) {
@@ -2508,33 +2408,30 @@ class _$_Error implements _Error {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)?
-        start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)?
-        debug,
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)?
-        print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)?
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )?
+    error,
     TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)?
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )?
+    testDone,
     TResult Function(int time, bool? success)? done,
     TResult Function(int time)? unknown,
   }) {
@@ -2544,33 +2441,30 @@ class _$_Error implements _Error {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)?
-        start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)?
-        debug,
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)?
-        print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)?
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )?
+    error,
     TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)?
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )?
+    testDone,
     TResult Function(int time, bool? success)? done,
     TResult Function(int time)? unknown,
     required TResult orElse(),
@@ -2641,24 +2535,22 @@ class _$_Error implements _Error {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ErrorToJson(
-      this,
-    );
+    return _$$_ErrorToJson(this);
   }
 }
 
 abstract class _Error implements Event {
-  const factory _Error(
-      {required final int time,
-      @JsonKey(name: 'testID') required final int testId,
-      required final String error,
-      @JsonKey(name: 'stackTrace') required final String stacktrace,
-      required final bool isFailure}) = _$_Error;
+  const factory _Error({
+    required final int time,
+    @JsonKey(name: 'testID') required final int testId,
+    required final String error,
+    @JsonKey(name: 'stackTrace') required final String stacktrace,
+    required final bool isFailure,
+  }) = _$_Error;
 
   factory _Error.fromJson(Map<String, dynamic> json) = _$_Error.fromJson;
 
   @override
-
   /// The time (in milliseconds) that has elapsed since the test runner started.
   int get time;
 
@@ -2677,30 +2569,26 @@ abstract class _Error implements Event {
   bool get isFailure;
   @override
   @JsonKey(ignore: true)
-  _$$_ErrorCopyWith<_$_Error> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$_ErrorCopyWith<_$_Error> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$_TestDoneCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$_TestDoneCopyWith(
-          _$_TestDone value, $Res Function(_$_TestDone) then) =
-      __$$_TestDoneCopyWithImpl<$Res>;
+  factory _$$_TestDoneCopyWith(_$_TestDone value, $Res Function(_$_TestDone) then) = __$$_TestDoneCopyWithImpl<$Res>;
   @override
-  $Res call(
-      {int time,
-      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-      @JsonKey(name: 'testID') int testId,
-      bool hidden,
-      bool skipped});
+  $Res call({
+    int time,
+    @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+    @JsonKey(name: 'testID') int testId,
+    bool hidden,
+    bool skipped,
+  });
 }
 
 /// @nodoc
-class __$$_TestDoneCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res>
-    implements _$$_TestDoneCopyWith<$Res> {
-  __$$_TestDoneCopyWithImpl(
-      _$_TestDone _value, $Res Function(_$_TestDone) _then)
-      : super(_value, (v) => _then(v as _$_TestDone));
+class __$$_TestDoneCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> implements _$$_TestDoneCopyWith<$Res> {
+  __$$_TestDoneCopyWithImpl(_$_TestDone _value, $Res Function(_$_TestDone) _then)
+    : super(_value, (v) => _then(v as _$_TestDone));
 
   @override
   _$_TestDone get _value => super._value as _$_TestDone;
@@ -2713,45 +2601,51 @@ class __$$_TestDoneCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res>
     Object? hidden = freezed,
     Object? skipped = freezed,
   }) {
-    return _then(_$_TestDone(
-      time: time == freezed
-          ? _value.time
-          : time // ignore: cast_nullable_to_non_nullable
-              as int,
-      result: result == freezed
-          ? _value.result
-          : result // ignore: cast_nullable_to_non_nullable
-              as TestResult,
-      testId: testId == freezed
-          ? _value.testId
-          : testId // ignore: cast_nullable_to_non_nullable
-              as int,
-      hidden: hidden == freezed
-          ? _value.hidden
-          : hidden // ignore: cast_nullable_to_non_nullable
-              as bool,
-      skipped: skipped == freezed
-          ? _value.skipped
-          : skipped // ignore: cast_nullable_to_non_nullable
-              as bool,
-    ));
+    return _then(
+      _$_TestDone(
+        time:
+            time == freezed
+                ? _value.time
+                : time // ignore: cast_nullable_to_non_nullable
+                    as int,
+        result:
+            result == freezed
+                ? _value.result
+                : result // ignore: cast_nullable_to_non_nullable
+                    as TestResult,
+        testId:
+            testId == freezed
+                ? _value.testId
+                : testId // ignore: cast_nullable_to_non_nullable
+                    as int,
+        hidden:
+            hidden == freezed
+                ? _value.hidden
+                : hidden // ignore: cast_nullable_to_non_nullable
+                    as bool,
+        skipped:
+            skipped == freezed
+                ? _value.skipped
+                : skipped // ignore: cast_nullable_to_non_nullable
+                    as bool,
+      ),
+    );
   }
 }
 
 /// @nodoc
 @JsonSerializable()
 class _$_TestDone implements _TestDone {
-  const _$_TestDone(
-      {required this.time,
-      @JsonKey(unknownEnumValue: TestResult.unknown) required this.result,
-      @JsonKey(name: 'testID') required this.testId,
-      required this.hidden,
-      required this.skipped,
-      final String? $type})
-      : $type = $type ?? 'testDone';
+  const _$_TestDone({
+    required this.time,
+    @JsonKey(unknownEnumValue: TestResult.unknown) required this.result,
+    @JsonKey(name: 'testID') required this.testId,
+    required this.hidden,
+    required this.skipped,
+    final String? $type,
+  }) : $type = $type ?? 'testDone';
 
-  factory _$_TestDone.fromJson(Map<String, dynamic> json) =>
-      _$$_TestDoneFromJson(json);
+  factory _$_TestDone.fromJson(Map<String, dynamic> json) => _$$_TestDoneFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -2798,48 +2692,50 @@ class _$_TestDone implements _TestDone {
   @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(time),
-      const DeepCollectionEquality().hash(result),
-      const DeepCollectionEquality().hash(testId),
-      const DeepCollectionEquality().hash(hidden),
-      const DeepCollectionEquality().hash(skipped));
+    runtimeType,
+    const DeepCollectionEquality().hash(time),
+    const DeepCollectionEquality().hash(result),
+    const DeepCollectionEquality().hash(testId),
+    const DeepCollectionEquality().hash(hidden),
+    const DeepCollectionEquality().hash(skipped),
+  );
 
   @JsonKey(ignore: true)
   @override
-  _$$_TestDoneCopyWith<_$_TestDone> get copyWith =>
-      __$$_TestDoneCopyWithImpl<_$_TestDone>(this, _$identity);
+  _$$_TestDoneCopyWith<_$_TestDone> get copyWith => __$$_TestDoneCopyWithImpl<_$_TestDone>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)
-        start,
+    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
-    required TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)
-        debug,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )
+    debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)
-        print,
+    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
     required TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )
+    error,
     required TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )
+    testDone,
     required TResult Function(int time, bool? success) done,
     required TResult Function(int time) unknown,
   }) {
@@ -2849,33 +2745,30 @@ class _$_TestDone implements _TestDone {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)?
-        start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)?
-        debug,
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)?
-        print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)?
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )?
+    error,
     TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)?
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )?
+    testDone,
     TResult Function(int time, bool? success)? done,
     TResult Function(int time)? unknown,
   }) {
@@ -2885,33 +2778,30 @@ class _$_TestDone implements _TestDone {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)?
-        start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)?
-        debug,
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)?
-        print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)?
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )?
+    error,
     TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)?
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )?
+    testDone,
     TResult Function(int time, bool? success)? done,
     TResult Function(int time)? unknown,
     required TResult orElse(),
@@ -2982,26 +2872,22 @@ class _$_TestDone implements _TestDone {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_TestDoneToJson(
-      this,
-    );
+    return _$$_TestDoneToJson(this);
   }
 }
 
 abstract class _TestDone implements Event {
-  const factory _TestDone(
-      {required final int time,
-      @JsonKey(unknownEnumValue: TestResult.unknown)
-          required final TestResult result,
-      @JsonKey(name: 'testID')
-          required final int testId,
-      required final bool hidden,
-      required final bool skipped}) = _$_TestDone;
+  const factory _TestDone({
+    required final int time,
+    @JsonKey(unknownEnumValue: TestResult.unknown) required final TestResult result,
+    @JsonKey(name: 'testID') required final int testId,
+    required final bool hidden,
+    required final bool skipped,
+  }) = _$_TestDone;
 
   factory _TestDone.fromJson(Map<String, dynamic> json) = _$_TestDone.fromJson;
 
   @override
-
   /// The time (in milliseconds) that has elapsed since the test runner started.
   int get time;
 
@@ -3020,50 +2906,46 @@ abstract class _TestDone implements Event {
   bool get skipped;
   @override
   @JsonKey(ignore: true)
-  _$$_TestDoneCopyWith<_$_TestDone> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$_TestDoneCopyWith<_$_TestDone> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$_DoneCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$_DoneCopyWith(_$_Done value, $Res Function(_$_Done) then) =
-      __$$_DoneCopyWithImpl<$Res>;
+  factory _$$_DoneCopyWith(_$_Done value, $Res Function(_$_Done) then) = __$$_DoneCopyWithImpl<$Res>;
   @override
   $Res call({int time, bool? success});
 }
 
 /// @nodoc
-class __$$_DoneCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res>
-    implements _$$_DoneCopyWith<$Res> {
-  __$$_DoneCopyWithImpl(_$_Done _value, $Res Function(_$_Done) _then)
-      : super(_value, (v) => _then(v as _$_Done));
+class __$$_DoneCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> implements _$$_DoneCopyWith<$Res> {
+  __$$_DoneCopyWithImpl(_$_Done _value, $Res Function(_$_Done) _then) : super(_value, (v) => _then(v as _$_Done));
 
   @override
   _$_Done get _value => super._value as _$_Done;
 
   @override
-  $Res call({
-    Object? time = freezed,
-    Object? success = freezed,
-  }) {
-    return _then(_$_Done(
-      time: time == freezed
-          ? _value.time
-          : time // ignore: cast_nullable_to_non_nullable
-              as int,
-      success: success == freezed
-          ? _value.success
-          : success // ignore: cast_nullable_to_non_nullable
-              as bool?,
-    ));
+  $Res call({Object? time = freezed, Object? success = freezed}) {
+    return _then(
+      _$_Done(
+        time:
+            time == freezed
+                ? _value.time
+                : time // ignore: cast_nullable_to_non_nullable
+                    as int,
+        success:
+            success == freezed
+                ? _value.success
+                : success // ignore: cast_nullable_to_non_nullable
+                    as bool?,
+      ),
+    );
   }
 }
 
 /// @nodoc
 @JsonSerializable()
 class _$_Done implements _Done {
-  const _$_Done({required this.time, this.success, final String? $type})
-      : $type = $type ?? 'done';
+  const _$_Done({required this.time, this.success, final String? $type}) : $type = $type ?? 'done';
 
   factory _$_Done.fromJson(Map<String, dynamic> json) => _$$_DoneFromJson(json);
 
@@ -3097,46 +2979,45 @@ class _$_Done implements _Done {
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(time),
-      const DeepCollectionEquality().hash(success));
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(time), const DeepCollectionEquality().hash(success));
 
   @JsonKey(ignore: true)
   @override
-  _$$_DoneCopyWith<_$_Done> get copyWith =>
-      __$$_DoneCopyWithImpl<_$_Done>(this, _$identity);
+  _$$_DoneCopyWith<_$_Done> get copyWith => __$$_DoneCopyWithImpl<_$_Done>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)
-        start,
+    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
-    required TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)
-        debug,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )
+    debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)
-        print,
+    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
     required TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )
+    error,
     required TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )
+    testDone,
     required TResult Function(int time, bool? success) done,
     required TResult Function(int time) unknown,
   }) {
@@ -3146,33 +3027,30 @@ class _$_Done implements _Done {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)?
-        start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)?
-        debug,
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)?
-        print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)?
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )?
+    error,
     TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)?
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )?
+    testDone,
     TResult Function(int time, bool? success)? done,
     TResult Function(int time)? unknown,
   }) {
@@ -3182,33 +3060,30 @@ class _$_Done implements _Done {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)?
-        start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)?
-        debug,
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)?
-        print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)?
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )?
+    error,
     TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)?
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )?
+    testDone,
     TResult Function(int time, bool? success)? done,
     TResult Function(int time)? unknown,
     required TResult orElse(),
@@ -3279,9 +3154,7 @@ class _$_Done implements _Done {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_DoneToJson(
-      this,
-    );
+    return _$$_DoneToJson(this);
   }
 }
 
@@ -3291,7 +3164,6 @@ abstract class _Done implements Event {
   factory _Done.fromJson(Map<String, dynamic> json) = _$_Done.fromJson;
 
   @override
-
   /// The time (in milliseconds) that has elapsed since the test runner started.
   int get time;
 
@@ -3307,43 +3179,39 @@ abstract class _Done implements Event {
 
 /// @nodoc
 abstract class _$$_UnknownCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$_UnknownCopyWith(
-          _$_Unknown value, $Res Function(_$_Unknown) then) =
-      __$$_UnknownCopyWithImpl<$Res>;
+  factory _$$_UnknownCopyWith(_$_Unknown value, $Res Function(_$_Unknown) then) = __$$_UnknownCopyWithImpl<$Res>;
   @override
   $Res call({int time});
 }
 
 /// @nodoc
-class __$$_UnknownCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res>
-    implements _$$_UnknownCopyWith<$Res> {
+class __$$_UnknownCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> implements _$$_UnknownCopyWith<$Res> {
   __$$_UnknownCopyWithImpl(_$_Unknown _value, $Res Function(_$_Unknown) _then)
-      : super(_value, (v) => _then(v as _$_Unknown));
+    : super(_value, (v) => _then(v as _$_Unknown));
 
   @override
   _$_Unknown get _value => super._value as _$_Unknown;
 
   @override
-  $Res call({
-    Object? time = freezed,
-  }) {
-    return _then(_$_Unknown(
-      time: time == freezed
-          ? _value.time
-          : time // ignore: cast_nullable_to_non_nullable
-              as int,
-    ));
+  $Res call({Object? time = freezed}) {
+    return _then(
+      _$_Unknown(
+        time:
+            time == freezed
+                ? _value.time
+                : time // ignore: cast_nullable_to_non_nullable
+                    as int,
+      ),
+    );
   }
 }
 
 /// @nodoc
 @JsonSerializable()
 class _$_Unknown implements _Unknown {
-  const _$_Unknown({required this.time, final String? $type})
-      : $type = $type ?? 'unknown';
+  const _$_Unknown({required this.time, final String? $type}) : $type = $type ?? 'unknown';
 
-  factory _$_Unknown.fromJson(Map<String, dynamic> json) =>
-      _$$_UnknownFromJson(json);
+  factory _$_Unknown.fromJson(Map<String, dynamic> json) => _$$_UnknownFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -3367,44 +3235,44 @@ class _$_Unknown implements _Unknown {
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(time));
+  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(time));
 
   @JsonKey(ignore: true)
   @override
-  _$$_UnknownCopyWith<_$_Unknown> get copyWith =>
-      __$$_UnknownCopyWithImpl<_$_Unknown>(this, _$identity);
+  _$$_UnknownCopyWith<_$_Unknown> get copyWith => __$$_UnknownCopyWithImpl<_$_Unknown>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)
-        start,
+    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
-    required TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)
-        debug,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )
+    debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)
-        print,
+    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
     required TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )
+    error,
     required TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )
+    testDone,
     required TResult Function(int time, bool? success) done,
     required TResult Function(int time) unknown,
   }) {
@@ -3414,33 +3282,30 @@ class _$_Unknown implements _Unknown {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)?
-        start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)?
-        debug,
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)?
-        print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)?
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )?
+    error,
     TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)?
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )?
+    testDone,
     TResult Function(int time, bool? success)? done,
     TResult Function(int time)? unknown,
   }) {
@@ -3450,33 +3315,30 @@ class _$_Unknown implements _Unknown {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-            int time, String protocolVersion, String? runnerVersion, int pid)?
-        start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId,
-            String? observatory, String? remoteDebugger)?
-        debug,
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId,
-            String messageType, String message)?
-        print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
-            int time,
-            @JsonKey(name: 'testID') int testId,
-            String error,
-            @JsonKey(name: 'stackTrace') String stacktrace,
-            bool isFailure)?
-        error,
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String error,
+      @JsonKey(name: 'stackTrace') String stacktrace,
+      bool isFailure,
+    )?
+    error,
     TResult Function(
-            int time,
-            @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
-            @JsonKey(name: 'testID') int testId,
-            bool hidden,
-            bool skipped)?
-        testDone,
+      int time,
+      @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
+      @JsonKey(name: 'testID') int testId,
+      bool hidden,
+      bool skipped,
+    )?
+    testDone,
     TResult Function(int time, bool? success)? done,
     TResult Function(int time)? unknown,
     required TResult orElse(),
@@ -3547,9 +3409,7 @@ class _$_Unknown implements _Unknown {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_UnknownToJson(
-      this,
-    );
+    return _$$_UnknownToJson(this);
   }
 }
 
@@ -3559,11 +3419,9 @@ abstract class _Unknown implements Event {
   factory _Unknown.fromJson(Map<String, dynamic> json) = _$_Unknown.fromJson;
 
   @override
-
   /// The time (in milliseconds) that has elapsed since the test runner started.
   int get time;
   @override
   @JsonKey(ignore: true)
-  _$$_UnknownCopyWith<_$_Unknown> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$_UnknownCopyWith<_$_Unknown> get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/parser/json_reporter_protocol_0_1/event.freezed.dart
+++ b/lib/src/parser/json_reporter_protocol_0_1/event.freezed.dart
@@ -49,13 +49,7 @@ mixin _$Event {
   int get time => throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )
-    start,
+    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -67,13 +61,7 @@ mixin _$Event {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )
-    print,
+    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -95,31 +83,14 @@ mixin _$Event {
   }) => throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )?
-    start,
+    TResult? Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult? Function(int time, int count)? allSuites,
     TResult? Function(int time, Suite suite)? suite,
-    TResult? Function(
-      int time,
-      @JsonKey(name: 'suiteID') int suiteId,
-      String? observatory,
-      String? remoteDebugger,
-    )?
+    TResult? Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
     debug,
     TResult? Function(int time, Group group)? group,
     TResult? Function(int time, Test test)? testStart,
-    TResult? Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )?
-    print,
+    TResult? Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -141,31 +112,14 @@ mixin _$Event {
   }) => throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )?
-    start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(
-      int time,
-      @JsonKey(name: 'suiteID') int suiteId,
-      String? observatory,
-      String? remoteDebugger,
-    )?
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )?
-    print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -241,15 +195,13 @@ mixin _$Event {
 
 /// @nodoc
 abstract class $EventCopyWith<$Res> {
-  factory $EventCopyWith(Event value, $Res Function(Event) then) =
-      _$EventCopyWithImpl<$Res, Event>;
+  factory $EventCopyWith(Event value, $Res Function(Event) then) = _$EventCopyWithImpl<$Res, Event>;
   @useResult
   $Res call({int time});
 }
 
 /// @nodoc
-class _$EventCopyWithImpl<$Res, $Val extends Event>
-    implements $EventCopyWith<$Res> {
+class _$EventCopyWithImpl<$Res, $Val extends Event> implements $EventCopyWith<$Res> {
   _$EventCopyWithImpl(this._value, this._then);
 
   // ignore: unused_field
@@ -277,23 +229,16 @@ class _$EventCopyWithImpl<$Res, $Val extends Event>
 
 /// @nodoc
 abstract class _$$StartImplCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$StartImplCopyWith(
-    _$StartImpl value,
-    $Res Function(_$StartImpl) then,
-  ) = __$$StartImplCopyWithImpl<$Res>;
+  factory _$$StartImplCopyWith(_$StartImpl value, $Res Function(_$StartImpl) then) = __$$StartImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int time, String protocolVersion, String? runnerVersion, int pid});
 }
 
 /// @nodoc
-class __$$StartImplCopyWithImpl<$Res>
-    extends _$EventCopyWithImpl<$Res, _$StartImpl>
+class __$$StartImplCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res, _$StartImpl>
     implements _$$StartImplCopyWith<$Res> {
-  __$$StartImplCopyWithImpl(
-    _$StartImpl _value,
-    $Res Function(_$StartImpl) _then,
-  ) : super(_value, _then);
+  __$$StartImplCopyWithImpl(_$StartImpl _value, $Res Function(_$StartImpl) _then) : super(_value, _then);
 
   /// Create a copy of Event
   /// with the given fields replaced by the non-null parameter values.
@@ -343,8 +288,7 @@ class _$StartImpl implements _Start {
     final String? $type,
   }) : $type = $type ?? 'start';
 
-  factory _$StartImpl.fromJson(Map<String, dynamic> json) =>
-      _$$StartImplFromJson(json);
+  factory _$StartImpl.fromJson(Map<String, dynamic> json) => _$$StartImplFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -381,36 +325,26 @@ class _$StartImpl implements _Start {
         (other.runtimeType == runtimeType &&
             other is _$StartImpl &&
             (identical(other.time, time) || other.time == time) &&
-            (identical(other.protocolVersion, protocolVersion) ||
-                other.protocolVersion == protocolVersion) &&
-            (identical(other.runnerVersion, runnerVersion) ||
-                other.runnerVersion == runnerVersion) &&
+            (identical(other.protocolVersion, protocolVersion) || other.protocolVersion == protocolVersion) &&
+            (identical(other.runnerVersion, runnerVersion) || other.runnerVersion == runnerVersion) &&
             (identical(other.pid, pid) || other.pid == pid));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, time, protocolVersion, runnerVersion, pid);
+  int get hashCode => Object.hash(runtimeType, time, protocolVersion, runnerVersion, pid);
 
   /// Create a copy of Event
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$StartImplCopyWith<_$StartImpl> get copyWith =>
-      __$$StartImplCopyWithImpl<_$StartImpl>(this, _$identity);
+  _$$StartImplCopyWith<_$StartImpl> get copyWith => __$$StartImplCopyWithImpl<_$StartImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )
-    start,
+    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -422,13 +356,7 @@ class _$StartImpl implements _Start {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )
-    print,
+    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -454,31 +382,14 @@ class _$StartImpl implements _Start {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )?
-    start,
+    TResult? Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult? Function(int time, int count)? allSuites,
     TResult? Function(int time, Suite suite)? suite,
-    TResult? Function(
-      int time,
-      @JsonKey(name: 'suiteID') int suiteId,
-      String? observatory,
-      String? remoteDebugger,
-    )?
+    TResult? Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
     debug,
     TResult? Function(int time, Group group)? group,
     TResult? Function(int time, Test test)? testStart,
-    TResult? Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )?
-    print,
+    TResult? Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -504,31 +415,14 @@ class _$StartImpl implements _Start {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )?
-    start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(
-      int time,
-      @JsonKey(name: 'suiteID') int suiteId,
-      String? observatory,
-      String? remoteDebugger,
-    )?
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )?
-    print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -651,29 +545,22 @@ abstract class _Start implements Event {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$StartImplCopyWith<_$StartImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$StartImplCopyWith<_$StartImpl> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$AllSuitesImplCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$AllSuitesImplCopyWith(
-    _$AllSuitesImpl value,
-    $Res Function(_$AllSuitesImpl) then,
-  ) = __$$AllSuitesImplCopyWithImpl<$Res>;
+  factory _$$AllSuitesImplCopyWith(_$AllSuitesImpl value, $Res Function(_$AllSuitesImpl) then) =
+      __$$AllSuitesImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int time, int count});
 }
 
 /// @nodoc
-class __$$AllSuitesImplCopyWithImpl<$Res>
-    extends _$EventCopyWithImpl<$Res, _$AllSuitesImpl>
+class __$$AllSuitesImplCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res, _$AllSuitesImpl>
     implements _$$AllSuitesImplCopyWith<$Res> {
-  __$$AllSuitesImplCopyWithImpl(
-    _$AllSuitesImpl _value,
-    $Res Function(_$AllSuitesImpl) _then,
-  ) : super(_value, _then);
+  __$$AllSuitesImplCopyWithImpl(_$AllSuitesImpl _value, $Res Function(_$AllSuitesImpl) _then) : super(_value, _then);
 
   /// Create a copy of Event
   /// with the given fields replaced by the non-null parameter values.
@@ -700,14 +587,9 @@ class __$$AllSuitesImplCopyWithImpl<$Res>
 /// @nodoc
 @JsonSerializable()
 class _$AllSuitesImpl implements _AllSuites {
-  const _$AllSuitesImpl({
-    required this.time,
-    required this.count,
-    final String? $type,
-  }) : $type = $type ?? 'allSuites';
+  const _$AllSuitesImpl({required this.time, required this.count, final String? $type}) : $type = $type ?? 'allSuites';
 
-  factory _$AllSuitesImpl.fromJson(Map<String, dynamic> json) =>
-      _$$AllSuitesImplFromJson(json);
+  factory _$AllSuitesImpl.fromJson(Map<String, dynamic> json) => _$$AllSuitesImplFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -749,13 +631,7 @@ class _$AllSuitesImpl implements _AllSuites {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )
-    start,
+    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -767,13 +643,7 @@ class _$AllSuitesImpl implements _AllSuites {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )
-    print,
+    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -799,31 +669,14 @@ class _$AllSuitesImpl implements _AllSuites {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )?
-    start,
+    TResult? Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult? Function(int time, int count)? allSuites,
     TResult? Function(int time, Suite suite)? suite,
-    TResult? Function(
-      int time,
-      @JsonKey(name: 'suiteID') int suiteId,
-      String? observatory,
-      String? remoteDebugger,
-    )?
+    TResult? Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
     debug,
     TResult? Function(int time, Group group)? group,
     TResult? Function(int time, Test test)? testStart,
-    TResult? Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )?
-    print,
+    TResult? Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -849,31 +702,14 @@ class _$AllSuitesImpl implements _AllSuites {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )?
-    start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(
-      int time,
-      @JsonKey(name: 'suiteID') int suiteId,
-      String? observatory,
-      String? remoteDebugger,
-    )?
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )?
-    print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -965,13 +801,9 @@ class _$AllSuitesImpl implements _AllSuites {
 }
 
 abstract class _AllSuites implements Event {
-  const factory _AllSuites({
-    required final int time,
-    required final int count,
-  }) = _$AllSuitesImpl;
+  const factory _AllSuites({required final int time, required final int count}) = _$AllSuitesImpl;
 
-  factory _AllSuites.fromJson(Map<String, dynamic> json) =
-      _$AllSuitesImpl.fromJson;
+  factory _AllSuites.fromJson(Map<String, dynamic> json) = _$AllSuitesImpl.fromJson;
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -984,16 +816,12 @@ abstract class _AllSuites implements Event {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$AllSuitesImplCopyWith<_$AllSuitesImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$AllSuitesImplCopyWith<_$AllSuitesImpl> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$SuiteImplCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$SuiteImplCopyWith(
-    _$SuiteImpl value,
-    $Res Function(_$SuiteImpl) then,
-  ) = __$$SuiteImplCopyWithImpl<$Res>;
+  factory _$$SuiteImplCopyWith(_$SuiteImpl value, $Res Function(_$SuiteImpl) then) = __$$SuiteImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int time, Suite suite});
@@ -1002,13 +830,9 @@ abstract class _$$SuiteImplCopyWith<$Res> implements $EventCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$SuiteImplCopyWithImpl<$Res>
-    extends _$EventCopyWithImpl<$Res, _$SuiteImpl>
+class __$$SuiteImplCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res, _$SuiteImpl>
     implements _$$SuiteImplCopyWith<$Res> {
-  __$$SuiteImplCopyWithImpl(
-    _$SuiteImpl _value,
-    $Res Function(_$SuiteImpl) _then,
-  ) : super(_value, _then);
+  __$$SuiteImplCopyWithImpl(_$SuiteImpl _value, $Res Function(_$SuiteImpl) _then) : super(_value, _then);
 
   /// Create a copy of Event
   /// with the given fields replaced by the non-null parameter values.
@@ -1045,14 +869,9 @@ class __$$SuiteImplCopyWithImpl<$Res>
 /// @nodoc
 @JsonSerializable()
 class _$SuiteImpl implements _Suite {
-  const _$SuiteImpl({
-    required this.time,
-    required this.suite,
-    final String? $type,
-  }) : $type = $type ?? 'suite';
+  const _$SuiteImpl({required this.time, required this.suite, final String? $type}) : $type = $type ?? 'suite';
 
-  factory _$SuiteImpl.fromJson(Map<String, dynamic> json) =>
-      _$$SuiteImplFromJson(json);
+  factory _$SuiteImpl.fromJson(Map<String, dynamic> json) => _$$SuiteImplFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -1088,19 +907,12 @@ class _$SuiteImpl implements _Suite {
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$SuiteImplCopyWith<_$SuiteImpl> get copyWith =>
-      __$$SuiteImplCopyWithImpl<_$SuiteImpl>(this, _$identity);
+  _$$SuiteImplCopyWith<_$SuiteImpl> get copyWith => __$$SuiteImplCopyWithImpl<_$SuiteImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )
-    start,
+    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -1112,13 +924,7 @@ class _$SuiteImpl implements _Suite {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )
-    print,
+    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -1144,31 +950,14 @@ class _$SuiteImpl implements _Suite {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )?
-    start,
+    TResult? Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult? Function(int time, int count)? allSuites,
     TResult? Function(int time, Suite suite)? suite,
-    TResult? Function(
-      int time,
-      @JsonKey(name: 'suiteID') int suiteId,
-      String? observatory,
-      String? remoteDebugger,
-    )?
+    TResult? Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
     debug,
     TResult? Function(int time, Group group)? group,
     TResult? Function(int time, Test test)? testStart,
-    TResult? Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )?
-    print,
+    TResult? Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -1194,31 +983,14 @@ class _$SuiteImpl implements _Suite {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )?
-    start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(
-      int time,
-      @JsonKey(name: 'suiteID') int suiteId,
-      String? observatory,
-      String? remoteDebugger,
-    )?
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )?
-    print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -1310,8 +1082,7 @@ class _$SuiteImpl implements _Suite {
 }
 
 abstract class _Suite implements Event {
-  const factory _Suite({required final int time, required final Suite suite}) =
-      _$SuiteImpl;
+  const factory _Suite({required final int time, required final Suite suite}) = _$SuiteImpl;
 
   factory _Suite.fromJson(Map<String, dynamic> json) = _$SuiteImpl.fromJson;
 
@@ -1326,34 +1097,21 @@ abstract class _Suite implements Event {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$SuiteImplCopyWith<_$SuiteImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$SuiteImplCopyWith<_$SuiteImpl> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$DebugImplCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$DebugImplCopyWith(
-    _$DebugImpl value,
-    $Res Function(_$DebugImpl) then,
-  ) = __$$DebugImplCopyWithImpl<$Res>;
+  factory _$$DebugImplCopyWith(_$DebugImpl value, $Res Function(_$DebugImpl) then) = __$$DebugImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({
-    int time,
-    @JsonKey(name: 'suiteID') int suiteId,
-    String? observatory,
-    String? remoteDebugger,
-  });
+  $Res call({int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger});
 }
 
 /// @nodoc
-class __$$DebugImplCopyWithImpl<$Res>
-    extends _$EventCopyWithImpl<$Res, _$DebugImpl>
+class __$$DebugImplCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res, _$DebugImpl>
     implements _$$DebugImplCopyWith<$Res> {
-  __$$DebugImplCopyWithImpl(
-    _$DebugImpl _value,
-    $Res Function(_$DebugImpl) _then,
-  ) : super(_value, _then);
+  __$$DebugImplCopyWithImpl(_$DebugImpl _value, $Res Function(_$DebugImpl) _then) : super(_value, _then);
 
   /// Create a copy of Event
   /// with the given fields replaced by the non-null parameter values.
@@ -1403,8 +1161,7 @@ class _$DebugImpl implements _Debug {
     final String? $type,
   }) : $type = $type ?? 'debug';
 
-  factory _$DebugImpl.fromJson(Map<String, dynamic> json) =>
-      _$$DebugImplFromJson(json);
+  factory _$DebugImpl.fromJson(Map<String, dynamic> json) => _$$DebugImplFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -1438,35 +1195,25 @@ class _$DebugImpl implements _Debug {
             other is _$DebugImpl &&
             (identical(other.time, time) || other.time == time) &&
             (identical(other.suiteId, suiteId) || other.suiteId == suiteId) &&
-            (identical(other.observatory, observatory) ||
-                other.observatory == observatory) &&
-            (identical(other.remoteDebugger, remoteDebugger) ||
-                other.remoteDebugger == remoteDebugger));
+            (identical(other.observatory, observatory) || other.observatory == observatory) &&
+            (identical(other.remoteDebugger, remoteDebugger) || other.remoteDebugger == remoteDebugger));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, time, suiteId, observatory, remoteDebugger);
+  int get hashCode => Object.hash(runtimeType, time, suiteId, observatory, remoteDebugger);
 
   /// Create a copy of Event
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$DebugImplCopyWith<_$DebugImpl> get copyWith =>
-      __$$DebugImplCopyWithImpl<_$DebugImpl>(this, _$identity);
+  _$$DebugImplCopyWith<_$DebugImpl> get copyWith => __$$DebugImplCopyWithImpl<_$DebugImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )
-    start,
+    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -1478,13 +1225,7 @@ class _$DebugImpl implements _Debug {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )
-    print,
+    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -1510,31 +1251,14 @@ class _$DebugImpl implements _Debug {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )?
-    start,
+    TResult? Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult? Function(int time, int count)? allSuites,
     TResult? Function(int time, Suite suite)? suite,
-    TResult? Function(
-      int time,
-      @JsonKey(name: 'suiteID') int suiteId,
-      String? observatory,
-      String? remoteDebugger,
-    )?
+    TResult? Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
     debug,
     TResult? Function(int time, Group group)? group,
     TResult? Function(int time, Test test)? testStart,
-    TResult? Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )?
-    print,
+    TResult? Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -1560,31 +1284,14 @@ class _$DebugImpl implements _Debug {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )?
-    start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(
-      int time,
-      @JsonKey(name: 'suiteID') int suiteId,
-      String? observatory,
-      String? remoteDebugger,
-    )?
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )?
-    print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -1703,16 +1410,12 @@ abstract class _Debug implements Event {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$DebugImplCopyWith<_$DebugImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$DebugImplCopyWith<_$DebugImpl> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$GroupImplCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$GroupImplCopyWith(
-    _$GroupImpl value,
-    $Res Function(_$GroupImpl) then,
-  ) = __$$GroupImplCopyWithImpl<$Res>;
+  factory _$$GroupImplCopyWith(_$GroupImpl value, $Res Function(_$GroupImpl) then) = __$$GroupImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int time, Group group});
@@ -1721,13 +1424,9 @@ abstract class _$$GroupImplCopyWith<$Res> implements $EventCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$GroupImplCopyWithImpl<$Res>
-    extends _$EventCopyWithImpl<$Res, _$GroupImpl>
+class __$$GroupImplCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res, _$GroupImpl>
     implements _$$GroupImplCopyWith<$Res> {
-  __$$GroupImplCopyWithImpl(
-    _$GroupImpl _value,
-    $Res Function(_$GroupImpl) _then,
-  ) : super(_value, _then);
+  __$$GroupImplCopyWithImpl(_$GroupImpl _value, $Res Function(_$GroupImpl) _then) : super(_value, _then);
 
   /// Create a copy of Event
   /// with the given fields replaced by the non-null parameter values.
@@ -1764,14 +1463,9 @@ class __$$GroupImplCopyWithImpl<$Res>
 /// @nodoc
 @JsonSerializable()
 class _$GroupImpl implements _Group {
-  const _$GroupImpl({
-    required this.time,
-    required this.group,
-    final String? $type,
-  }) : $type = $type ?? 'group';
+  const _$GroupImpl({required this.time, required this.group, final String? $type}) : $type = $type ?? 'group';
 
-  factory _$GroupImpl.fromJson(Map<String, dynamic> json) =>
-      _$$GroupImplFromJson(json);
+  factory _$GroupImpl.fromJson(Map<String, dynamic> json) => _$$GroupImplFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -1807,19 +1501,12 @@ class _$GroupImpl implements _Group {
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$GroupImplCopyWith<_$GroupImpl> get copyWith =>
-      __$$GroupImplCopyWithImpl<_$GroupImpl>(this, _$identity);
+  _$$GroupImplCopyWith<_$GroupImpl> get copyWith => __$$GroupImplCopyWithImpl<_$GroupImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )
-    start,
+    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -1831,13 +1518,7 @@ class _$GroupImpl implements _Group {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )
-    print,
+    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -1863,31 +1544,14 @@ class _$GroupImpl implements _Group {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )?
-    start,
+    TResult? Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult? Function(int time, int count)? allSuites,
     TResult? Function(int time, Suite suite)? suite,
-    TResult? Function(
-      int time,
-      @JsonKey(name: 'suiteID') int suiteId,
-      String? observatory,
-      String? remoteDebugger,
-    )?
+    TResult? Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
     debug,
     TResult? Function(int time, Group group)? group,
     TResult? Function(int time, Test test)? testStart,
-    TResult? Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )?
-    print,
+    TResult? Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -1913,31 +1577,14 @@ class _$GroupImpl implements _Group {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )?
-    start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(
-      int time,
-      @JsonKey(name: 'suiteID') int suiteId,
-      String? observatory,
-      String? remoteDebugger,
-    )?
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )?
-    print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -2029,8 +1676,7 @@ class _$GroupImpl implements _Group {
 }
 
 abstract class _Group implements Event {
-  const factory _Group({required final int time, required final Group group}) =
-      _$GroupImpl;
+  const factory _Group({required final int time, required final Group group}) = _$GroupImpl;
 
   factory _Group.fromJson(Map<String, dynamic> json) = _$GroupImpl.fromJson;
 
@@ -2045,16 +1691,13 @@ abstract class _Group implements Event {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$GroupImplCopyWith<_$GroupImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$GroupImplCopyWith<_$GroupImpl> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$TestStartImplCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$TestStartImplCopyWith(
-    _$TestStartImpl value,
-    $Res Function(_$TestStartImpl) then,
-  ) = __$$TestStartImplCopyWithImpl<$Res>;
+  factory _$$TestStartImplCopyWith(_$TestStartImpl value, $Res Function(_$TestStartImpl) then) =
+      __$$TestStartImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int time, Test test});
@@ -2063,13 +1706,9 @@ abstract class _$$TestStartImplCopyWith<$Res> implements $EventCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$TestStartImplCopyWithImpl<$Res>
-    extends _$EventCopyWithImpl<$Res, _$TestStartImpl>
+class __$$TestStartImplCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res, _$TestStartImpl>
     implements _$$TestStartImplCopyWith<$Res> {
-  __$$TestStartImplCopyWithImpl(
-    _$TestStartImpl _value,
-    $Res Function(_$TestStartImpl) _then,
-  ) : super(_value, _then);
+  __$$TestStartImplCopyWithImpl(_$TestStartImpl _value, $Res Function(_$TestStartImpl) _then) : super(_value, _then);
 
   /// Create a copy of Event
   /// with the given fields replaced by the non-null parameter values.
@@ -2106,14 +1745,9 @@ class __$$TestStartImplCopyWithImpl<$Res>
 /// @nodoc
 @JsonSerializable()
 class _$TestStartImpl implements _TestStart {
-  const _$TestStartImpl({
-    required this.time,
-    required this.test,
-    final String? $type,
-  }) : $type = $type ?? 'testStart';
+  const _$TestStartImpl({required this.time, required this.test, final String? $type}) : $type = $type ?? 'testStart';
 
-  factory _$TestStartImpl.fromJson(Map<String, dynamic> json) =>
-      _$$TestStartImplFromJson(json);
+  factory _$TestStartImpl.fromJson(Map<String, dynamic> json) => _$$TestStartImplFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -2155,13 +1789,7 @@ class _$TestStartImpl implements _TestStart {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )
-    start,
+    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -2173,13 +1801,7 @@ class _$TestStartImpl implements _TestStart {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )
-    print,
+    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -2205,31 +1827,14 @@ class _$TestStartImpl implements _TestStart {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )?
-    start,
+    TResult? Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult? Function(int time, int count)? allSuites,
     TResult? Function(int time, Suite suite)? suite,
-    TResult? Function(
-      int time,
-      @JsonKey(name: 'suiteID') int suiteId,
-      String? observatory,
-      String? remoteDebugger,
-    )?
+    TResult? Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
     debug,
     TResult? Function(int time, Group group)? group,
     TResult? Function(int time, Test test)? testStart,
-    TResult? Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )?
-    print,
+    TResult? Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -2255,31 +1860,14 @@ class _$TestStartImpl implements _TestStart {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )?
-    start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(
-      int time,
-      @JsonKey(name: 'suiteID') int suiteId,
-      String? observatory,
-      String? remoteDebugger,
-    )?
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )?
-    print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -2371,13 +1959,9 @@ class _$TestStartImpl implements _TestStart {
 }
 
 abstract class _TestStart implements Event {
-  const factory _TestStart({
-    required final int time,
-    required final Test test,
-  }) = _$TestStartImpl;
+  const factory _TestStart({required final int time, required final Test test}) = _$TestStartImpl;
 
-  factory _TestStart.fromJson(Map<String, dynamic> json) =
-      _$TestStartImpl.fromJson;
+  factory _TestStart.fromJson(Map<String, dynamic> json) = _$TestStartImpl.fromJson;
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -2390,45 +1974,27 @@ abstract class _TestStart implements Event {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$TestStartImplCopyWith<_$TestStartImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$TestStartImplCopyWith<_$TestStartImpl> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$PrintImplCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$PrintImplCopyWith(
-    _$PrintImpl value,
-    $Res Function(_$PrintImpl) then,
-  ) = __$$PrintImplCopyWithImpl<$Res>;
+  factory _$$PrintImplCopyWith(_$PrintImpl value, $Res Function(_$PrintImpl) then) = __$$PrintImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({
-    int time,
-    @JsonKey(name: 'testID') int testId,
-    String messageType,
-    String message,
-  });
+  $Res call({int time, @JsonKey(name: 'testID') int testId, String messageType, String message});
 }
 
 /// @nodoc
-class __$$PrintImplCopyWithImpl<$Res>
-    extends _$EventCopyWithImpl<$Res, _$PrintImpl>
+class __$$PrintImplCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res, _$PrintImpl>
     implements _$$PrintImplCopyWith<$Res> {
-  __$$PrintImplCopyWithImpl(
-    _$PrintImpl _value,
-    $Res Function(_$PrintImpl) _then,
-  ) : super(_value, _then);
+  __$$PrintImplCopyWithImpl(_$PrintImpl _value, $Res Function(_$PrintImpl) _then) : super(_value, _then);
 
   /// Create a copy of Event
   /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
-  $Res call({
-    Object? time = null,
-    Object? testId = null,
-    Object? messageType = null,
-    Object? message = null,
-  }) {
+  $Res call({Object? time = null, Object? testId = null, Object? messageType = null, Object? message = null}) {
     return _then(
       _$PrintImpl(
         time:
@@ -2467,8 +2033,7 @@ class _$PrintImpl implements _Print {
     final String? $type,
   }) : $type = $type ?? 'print';
 
-  factory _$PrintImpl.fromJson(Map<String, dynamic> json) =>
-      _$$PrintImplFromJson(json);
+  factory _$PrintImpl.fromJson(Map<String, dynamic> json) => _$$PrintImplFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -2502,34 +2067,25 @@ class _$PrintImpl implements _Print {
             other is _$PrintImpl &&
             (identical(other.time, time) || other.time == time) &&
             (identical(other.testId, testId) || other.testId == testId) &&
-            (identical(other.messageType, messageType) ||
-                other.messageType == messageType) &&
+            (identical(other.messageType, messageType) || other.messageType == messageType) &&
             (identical(other.message, message) || other.message == message));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, time, testId, messageType, message);
+  int get hashCode => Object.hash(runtimeType, time, testId, messageType, message);
 
   /// Create a copy of Event
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$PrintImplCopyWith<_$PrintImpl> get copyWith =>
-      __$$PrintImplCopyWithImpl<_$PrintImpl>(this, _$identity);
+  _$$PrintImplCopyWith<_$PrintImpl> get copyWith => __$$PrintImplCopyWithImpl<_$PrintImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )
-    start,
+    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -2541,13 +2097,7 @@ class _$PrintImpl implements _Print {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )
-    print,
+    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -2573,31 +2123,14 @@ class _$PrintImpl implements _Print {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )?
-    start,
+    TResult? Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult? Function(int time, int count)? allSuites,
     TResult? Function(int time, Suite suite)? suite,
-    TResult? Function(
-      int time,
-      @JsonKey(name: 'suiteID') int suiteId,
-      String? observatory,
-      String? remoteDebugger,
-    )?
+    TResult? Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
     debug,
     TResult? Function(int time, Group group)? group,
     TResult? Function(int time, Test test)? testStart,
-    TResult? Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )?
-    print,
+    TResult? Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -2623,31 +2156,14 @@ class _$PrintImpl implements _Print {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )?
-    start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(
-      int time,
-      @JsonKey(name: 'suiteID') int suiteId,
-      String? observatory,
-      String? remoteDebugger,
-    )?
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )?
-    print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -2766,16 +2282,12 @@ abstract class _Print implements Event {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$PrintImplCopyWith<_$PrintImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$PrintImplCopyWith<_$PrintImpl> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$ErrorImplCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$ErrorImplCopyWith(
-    _$ErrorImpl value,
-    $Res Function(_$ErrorImpl) then,
-  ) = __$$ErrorImplCopyWithImpl<$Res>;
+  factory _$$ErrorImplCopyWith(_$ErrorImpl value, $Res Function(_$ErrorImpl) then) = __$$ErrorImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({
@@ -2788,13 +2300,9 @@ abstract class _$$ErrorImplCopyWith<$Res> implements $EventCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$ErrorImplCopyWithImpl<$Res>
-    extends _$EventCopyWithImpl<$Res, _$ErrorImpl>
+class __$$ErrorImplCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res, _$ErrorImpl>
     implements _$$ErrorImplCopyWith<$Res> {
-  __$$ErrorImplCopyWithImpl(
-    _$ErrorImpl _value,
-    $Res Function(_$ErrorImpl) _then,
-  ) : super(_value, _then);
+  __$$ErrorImplCopyWithImpl(_$ErrorImpl _value, $Res Function(_$ErrorImpl) _then) : super(_value, _then);
 
   /// Create a copy of Event
   /// with the given fields replaced by the non-null parameter values.
@@ -2851,8 +2359,7 @@ class _$ErrorImpl implements _Error {
     final String? $type,
   }) : $type = $type ?? 'error';
 
-  factory _$ErrorImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ErrorImplFromJson(json);
+  factory _$ErrorImpl.fromJson(Map<String, dynamic> json) => _$$ErrorImplFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -2892,35 +2399,25 @@ class _$ErrorImpl implements _Error {
             (identical(other.time, time) || other.time == time) &&
             (identical(other.testId, testId) || other.testId == testId) &&
             (identical(other.error, error) || other.error == error) &&
-            (identical(other.stacktrace, stacktrace) ||
-                other.stacktrace == stacktrace) &&
-            (identical(other.isFailure, isFailure) ||
-                other.isFailure == isFailure));
+            (identical(other.stacktrace, stacktrace) || other.stacktrace == stacktrace) &&
+            (identical(other.isFailure, isFailure) || other.isFailure == isFailure));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, time, testId, error, stacktrace, isFailure);
+  int get hashCode => Object.hash(runtimeType, time, testId, error, stacktrace, isFailure);
 
   /// Create a copy of Event
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$ErrorImplCopyWith<_$ErrorImpl> get copyWith =>
-      __$$ErrorImplCopyWithImpl<_$ErrorImpl>(this, _$identity);
+  _$$ErrorImplCopyWith<_$ErrorImpl> get copyWith => __$$ErrorImplCopyWithImpl<_$ErrorImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )
-    start,
+    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -2932,13 +2429,7 @@ class _$ErrorImpl implements _Error {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )
-    print,
+    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -2964,31 +2455,14 @@ class _$ErrorImpl implements _Error {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )?
-    start,
+    TResult? Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult? Function(int time, int count)? allSuites,
     TResult? Function(int time, Suite suite)? suite,
-    TResult? Function(
-      int time,
-      @JsonKey(name: 'suiteID') int suiteId,
-      String? observatory,
-      String? remoteDebugger,
-    )?
+    TResult? Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
     debug,
     TResult? Function(int time, Group group)? group,
     TResult? Function(int time, Test test)? testStart,
-    TResult? Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )?
-    print,
+    TResult? Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -3014,31 +2488,14 @@ class _$ErrorImpl implements _Error {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )?
-    start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(
-      int time,
-      @JsonKey(name: 'suiteID') int suiteId,
-      String? observatory,
-      String? remoteDebugger,
-    )?
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )?
-    print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -3162,16 +2619,13 @@ abstract class _Error implements Event {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$ErrorImplCopyWith<_$ErrorImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$ErrorImplCopyWith<_$ErrorImpl> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$TestDoneImplCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$TestDoneImplCopyWith(
-    _$TestDoneImpl value,
-    $Res Function(_$TestDoneImpl) then,
-  ) = __$$TestDoneImplCopyWithImpl<$Res>;
+  factory _$$TestDoneImplCopyWith(_$TestDoneImpl value, $Res Function(_$TestDoneImpl) then) =
+      __$$TestDoneImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({
@@ -3184,13 +2638,9 @@ abstract class _$$TestDoneImplCopyWith<$Res> implements $EventCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$TestDoneImplCopyWithImpl<$Res>
-    extends _$EventCopyWithImpl<$Res, _$TestDoneImpl>
+class __$$TestDoneImplCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res, _$TestDoneImpl>
     implements _$$TestDoneImplCopyWith<$Res> {
-  __$$TestDoneImplCopyWithImpl(
-    _$TestDoneImpl _value,
-    $Res Function(_$TestDoneImpl) _then,
-  ) : super(_value, _then);
+  __$$TestDoneImplCopyWithImpl(_$TestDoneImpl _value, $Res Function(_$TestDoneImpl) _then) : super(_value, _then);
 
   /// Create a copy of Event
   /// with the given fields replaced by the non-null parameter values.
@@ -3247,8 +2697,7 @@ class _$TestDoneImpl implements _TestDone {
     final String? $type,
   }) : $type = $type ?? 'testDone';
 
-  factory _$TestDoneImpl.fromJson(Map<String, dynamic> json) =>
-      _$$TestDoneImplFromJson(json);
+  factory _$TestDoneImpl.fromJson(Map<String, dynamic> json) => _$$TestDoneImplFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -3294,8 +2743,7 @@ class _$TestDoneImpl implements _TestDone {
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, time, result, testId, hidden, skipped);
+  int get hashCode => Object.hash(runtimeType, time, result, testId, hidden, skipped);
 
   /// Create a copy of Event
   /// with the given fields replaced by the non-null parameter values.
@@ -3308,13 +2756,7 @@ class _$TestDoneImpl implements _TestDone {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )
-    start,
+    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -3326,13 +2768,7 @@ class _$TestDoneImpl implements _TestDone {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )
-    print,
+    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -3358,31 +2794,14 @@ class _$TestDoneImpl implements _TestDone {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )?
-    start,
+    TResult? Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult? Function(int time, int count)? allSuites,
     TResult? Function(int time, Suite suite)? suite,
-    TResult? Function(
-      int time,
-      @JsonKey(name: 'suiteID') int suiteId,
-      String? observatory,
-      String? remoteDebugger,
-    )?
+    TResult? Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
     debug,
     TResult? Function(int time, Group group)? group,
     TResult? Function(int time, Test test)? testStart,
-    TResult? Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )?
-    print,
+    TResult? Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -3408,31 +2827,14 @@ class _$TestDoneImpl implements _TestDone {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )?
-    start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(
-      int time,
-      @JsonKey(name: 'suiteID') int suiteId,
-      String? observatory,
-      String? remoteDebugger,
-    )?
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )?
-    print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -3526,15 +2928,13 @@ class _$TestDoneImpl implements _TestDone {
 abstract class _TestDone implements Event {
   const factory _TestDone({
     required final int time,
-    @JsonKey(unknownEnumValue: TestResult.unknown)
-    required final TestResult result,
+    @JsonKey(unknownEnumValue: TestResult.unknown) required final TestResult result,
     @JsonKey(name: 'testID') required final int testId,
     required final bool hidden,
     required final bool skipped,
   }) = _$TestDoneImpl;
 
-  factory _TestDone.fromJson(Map<String, dynamic> json) =
-      _$TestDoneImpl.fromJson;
+  factory _TestDone.fromJson(Map<String, dynamic> json) = _$TestDoneImpl.fromJson;
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -3558,27 +2958,21 @@ abstract class _TestDone implements Event {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$TestDoneImplCopyWith<_$TestDoneImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$TestDoneImplCopyWith<_$TestDoneImpl> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$DoneImplCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$DoneImplCopyWith(
-    _$DoneImpl value,
-    $Res Function(_$DoneImpl) then,
-  ) = __$$DoneImplCopyWithImpl<$Res>;
+  factory _$$DoneImplCopyWith(_$DoneImpl value, $Res Function(_$DoneImpl) then) = __$$DoneImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int time, bool? success});
 }
 
 /// @nodoc
-class __$$DoneImplCopyWithImpl<$Res>
-    extends _$EventCopyWithImpl<$Res, _$DoneImpl>
+class __$$DoneImplCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res, _$DoneImpl>
     implements _$$DoneImplCopyWith<$Res> {
-  __$$DoneImplCopyWithImpl(_$DoneImpl _value, $Res Function(_$DoneImpl) _then)
-    : super(_value, _then);
+  __$$DoneImplCopyWithImpl(_$DoneImpl _value, $Res Function(_$DoneImpl) _then) : super(_value, _then);
 
   /// Create a copy of Event
   /// with the given fields replaced by the non-null parameter values.
@@ -3605,11 +2999,9 @@ class __$$DoneImplCopyWithImpl<$Res>
 /// @nodoc
 @JsonSerializable()
 class _$DoneImpl implements _Done {
-  const _$DoneImpl({required this.time, this.success, final String? $type})
-    : $type = $type ?? 'done';
+  const _$DoneImpl({required this.time, this.success, final String? $type}) : $type = $type ?? 'done';
 
-  factory _$DoneImpl.fromJson(Map<String, dynamic> json) =>
-      _$$DoneImplFromJson(json);
+  factory _$DoneImpl.fromJson(Map<String, dynamic> json) => _$$DoneImplFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -3648,19 +3040,12 @@ class _$DoneImpl implements _Done {
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$DoneImplCopyWith<_$DoneImpl> get copyWith =>
-      __$$DoneImplCopyWithImpl<_$DoneImpl>(this, _$identity);
+  _$$DoneImplCopyWith<_$DoneImpl> get copyWith => __$$DoneImplCopyWithImpl<_$DoneImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )
-    start,
+    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -3672,13 +3057,7 @@ class _$DoneImpl implements _Done {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )
-    print,
+    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -3704,31 +3083,14 @@ class _$DoneImpl implements _Done {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )?
-    start,
+    TResult? Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult? Function(int time, int count)? allSuites,
     TResult? Function(int time, Suite suite)? suite,
-    TResult? Function(
-      int time,
-      @JsonKey(name: 'suiteID') int suiteId,
-      String? observatory,
-      String? remoteDebugger,
-    )?
+    TResult? Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
     debug,
     TResult? Function(int time, Group group)? group,
     TResult? Function(int time, Test test)? testStart,
-    TResult? Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )?
-    print,
+    TResult? Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -3754,31 +3116,14 @@ class _$DoneImpl implements _Done {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )?
-    start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(
-      int time,
-      @JsonKey(name: 'suiteID') int suiteId,
-      String? observatory,
-      String? remoteDebugger,
-    )?
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )?
-    print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -3870,8 +3215,7 @@ class _$DoneImpl implements _Done {
 }
 
 abstract class _Done implements Event {
-  const factory _Done({required final int time, final bool? success}) =
-      _$DoneImpl;
+  const factory _Done({required final int time, final bool? success}) = _$DoneImpl;
 
   factory _Done.fromJson(Map<String, dynamic> json) = _$DoneImpl.fromJson;
 
@@ -3889,29 +3233,22 @@ abstract class _Done implements Event {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$DoneImplCopyWith<_$DoneImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$DoneImplCopyWith<_$DoneImpl> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$UnknownImplCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$UnknownImplCopyWith(
-    _$UnknownImpl value,
-    $Res Function(_$UnknownImpl) then,
-  ) = __$$UnknownImplCopyWithImpl<$Res>;
+  factory _$$UnknownImplCopyWith(_$UnknownImpl value, $Res Function(_$UnknownImpl) then) =
+      __$$UnknownImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int time});
 }
 
 /// @nodoc
-class __$$UnknownImplCopyWithImpl<$Res>
-    extends _$EventCopyWithImpl<$Res, _$UnknownImpl>
+class __$$UnknownImplCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res, _$UnknownImpl>
     implements _$$UnknownImplCopyWith<$Res> {
-  __$$UnknownImplCopyWithImpl(
-    _$UnknownImpl _value,
-    $Res Function(_$UnknownImpl) _then,
-  ) : super(_value, _then);
+  __$$UnknownImplCopyWithImpl(_$UnknownImpl _value, $Res Function(_$UnknownImpl) _then) : super(_value, _then);
 
   /// Create a copy of Event
   /// with the given fields replaced by the non-null parameter values.
@@ -3933,11 +3270,9 @@ class __$$UnknownImplCopyWithImpl<$Res>
 /// @nodoc
 @JsonSerializable()
 class _$UnknownImpl implements _Unknown {
-  const _$UnknownImpl({required this.time, final String? $type})
-    : $type = $type ?? 'unknown';
+  const _$UnknownImpl({required this.time, final String? $type}) : $type = $type ?? 'unknown';
 
-  factory _$UnknownImpl.fromJson(Map<String, dynamic> json) =>
-      _$$UnknownImplFromJson(json);
+  factory _$UnknownImpl.fromJson(Map<String, dynamic> json) => _$$UnknownImplFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -3968,19 +3303,12 @@ class _$UnknownImpl implements _Unknown {
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$UnknownImplCopyWith<_$UnknownImpl> get copyWith =>
-      __$$UnknownImplCopyWithImpl<_$UnknownImpl>(this, _$identity);
+  _$$UnknownImplCopyWith<_$UnknownImpl> get copyWith => __$$UnknownImplCopyWithImpl<_$UnknownImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )
-    start,
+    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -3992,13 +3320,7 @@ class _$UnknownImpl implements _Unknown {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )
-    print,
+    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -4024,31 +3346,14 @@ class _$UnknownImpl implements _Unknown {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )?
-    start,
+    TResult? Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult? Function(int time, int count)? allSuites,
     TResult? Function(int time, Suite suite)? suite,
-    TResult? Function(
-      int time,
-      @JsonKey(name: 'suiteID') int suiteId,
-      String? observatory,
-      String? remoteDebugger,
-    )?
+    TResult? Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
     debug,
     TResult? Function(int time, Group group)? group,
     TResult? Function(int time, Test test)? testStart,
-    TResult? Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )?
-    print,
+    TResult? Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -4074,31 +3379,14 @@ class _$UnknownImpl implements _Unknown {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-      int time,
-      String protocolVersion,
-      String? runnerVersion,
-      int pid,
-    )?
-    start,
+    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(
-      int time,
-      @JsonKey(name: 'suiteID') int suiteId,
-      String? observatory,
-      String? remoteDebugger,
-    )?
+    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(
-      int time,
-      @JsonKey(name: 'testID') int testId,
-      String messageType,
-      String message,
-    )?
-    print,
+    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -4202,6 +3490,5 @@ abstract class _Unknown implements Event {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$UnknownImplCopyWith<_$UnknownImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$UnknownImplCopyWith<_$UnknownImpl> get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/parser/json_reporter_protocol_0_1/event.freezed.dart
+++ b/lib/src/parser/json_reporter_protocol_0_1/event.freezed.dart
@@ -1,7 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
-// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
 part of 'event.dart';
 
@@ -12,7 +12,7 @@ part of 'event.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods',
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
 );
 
 Event _$EventFromJson(Map<String, dynamic> json) {
@@ -49,7 +49,13 @@ mixin _$Event {
   int get time => throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
+    required TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )
+    start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -61,7 +67,13 @@ mixin _$Event {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )
+    print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -83,15 +95,32 @@ mixin _$Event {
   }) => throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
-    TResult Function(int time, int count)? allSuites,
-    TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult? Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
+    TResult? Function(int time, int count)? allSuites,
+    TResult? Function(int time, Suite suite)? suite,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
-    TResult Function(int time, Group group)? group,
-    TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
-    TResult Function(
+    TResult? Function(int time, Group group)? group,
+    TResult? Function(int time, Test test)? testStart,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
+    TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
       String error,
@@ -99,7 +128,7 @@ mixin _$Event {
       bool isFailure,
     )?
     error,
-    TResult Function(
+    TResult? Function(
       int time,
       @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
       @JsonKey(name: 'testID') int testId,
@@ -107,19 +136,36 @@ mixin _$Event {
       bool skipped,
     )?
     testDone,
-    TResult Function(int time, bool? success)? done,
-    TResult Function(int time)? unknown,
+    TResult? Function(int time, bool? success)? done,
+    TResult? Function(int time)? unknown,
   }) => throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -156,17 +202,17 @@ mixin _$Event {
   }) => throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult Function(_Start value)? start,
-    TResult Function(_AllSuites value)? allSuites,
-    TResult Function(_Suite value)? suite,
-    TResult Function(_Debug value)? debug,
-    TResult Function(_Group value)? group,
-    TResult Function(_TestStart value)? testStart,
-    TResult Function(_Print value)? print,
-    TResult Function(_Error value)? error,
-    TResult Function(_TestDone value)? testDone,
-    TResult Function(_Done value)? done,
-    TResult Function(_Unknown value)? unknown,
+    TResult? Function(_Start value)? start,
+    TResult? Function(_AllSuites value)? allSuites,
+    TResult? Function(_Suite value)? suite,
+    TResult? Function(_Debug value)? debug,
+    TResult? Function(_Group value)? group,
+    TResult? Function(_TestStart value)? testStart,
+    TResult? Function(_Print value)? print,
+    TResult? Function(_Error value)? error,
+    TResult? Function(_TestDone value)? testDone,
+    TResult? Function(_Done value)? done,
+    TResult? Function(_Unknown value)? unknown,
   }) => throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
@@ -183,79 +229,101 @@ mixin _$Event {
     TResult Function(_Unknown value)? unknown,
     required TResult orElse(),
   }) => throw _privateConstructorUsedError;
+
+  /// Serializes this Event to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $EventCopyWith<Event> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class $EventCopyWith<$Res> {
-  factory $EventCopyWith(Event value, $Res Function(Event) then) = _$EventCopyWithImpl<$Res>;
+  factory $EventCopyWith(Event value, $Res Function(Event) then) =
+      _$EventCopyWithImpl<$Res, Event>;
+  @useResult
   $Res call({int time});
 }
 
 /// @nodoc
-class _$EventCopyWithImpl<$Res> implements $EventCopyWith<$Res> {
+class _$EventCopyWithImpl<$Res, $Val extends Event>
+    implements $EventCopyWith<$Res> {
   _$EventCopyWithImpl(this._value, this._then);
 
-  final Event _value;
   // ignore: unused_field
-  final $Res Function(Event) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
   @override
-  $Res call({Object? time = freezed}) {
+  $Res call({Object? time = null}) {
     return _then(
       _value.copyWith(
-        time:
-            time == freezed
-                ? _value.time
-                : time // ignore: cast_nullable_to_non_nullable
-                    as int,
-      ),
+            time:
+                null == time
+                    ? _value.time
+                    : time // ignore: cast_nullable_to_non_nullable
+                        as int,
+          )
+          as $Val,
     );
   }
 }
 
 /// @nodoc
-abstract class _$$_StartCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$_StartCopyWith(_$_Start value, $Res Function(_$_Start) then) = __$$_StartCopyWithImpl<$Res>;
+abstract class _$$StartImplCopyWith<$Res> implements $EventCopyWith<$Res> {
+  factory _$$StartImplCopyWith(
+    _$StartImpl value,
+    $Res Function(_$StartImpl) then,
+  ) = __$$StartImplCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call({int time, String protocolVersion, String? runnerVersion, int pid});
 }
 
 /// @nodoc
-class __$$_StartCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> implements _$$_StartCopyWith<$Res> {
-  __$$_StartCopyWithImpl(_$_Start _value, $Res Function(_$_Start) _then) : super(_value, (v) => _then(v as _$_Start));
+class __$$StartImplCopyWithImpl<$Res>
+    extends _$EventCopyWithImpl<$Res, _$StartImpl>
+    implements _$$StartImplCopyWith<$Res> {
+  __$$StartImplCopyWithImpl(
+    _$StartImpl _value,
+    $Res Function(_$StartImpl) _then,
+  ) : super(_value, _then);
 
-  @override
-  _$_Start get _value => super._value as _$_Start;
-
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? time = freezed,
-    Object? protocolVersion = freezed,
+    Object? time = null,
+    Object? protocolVersion = null,
     Object? runnerVersion = freezed,
-    Object? pid = freezed,
+    Object? pid = null,
   }) {
     return _then(
-      _$_Start(
+      _$StartImpl(
         time:
-            time == freezed
+            null == time
                 ? _value.time
                 : time // ignore: cast_nullable_to_non_nullable
                     as int,
         protocolVersion:
-            protocolVersion == freezed
+            null == protocolVersion
                 ? _value.protocolVersion
                 : protocolVersion // ignore: cast_nullable_to_non_nullable
                     as String,
         runnerVersion:
-            runnerVersion == freezed
+            freezed == runnerVersion
                 ? _value.runnerVersion
                 : runnerVersion // ignore: cast_nullable_to_non_nullable
                     as String?,
         pid:
-            pid == freezed
+            null == pid
                 ? _value.pid
                 : pid // ignore: cast_nullable_to_non_nullable
                     as int,
@@ -266,8 +334,8 @@ class __$$_StartCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> implements 
 
 /// @nodoc
 @JsonSerializable()
-class _$_Start implements _Start {
-  const _$_Start({
+class _$StartImpl implements _Start {
+  const _$StartImpl({
     required this.time,
     required this.protocolVersion,
     this.runnerVersion,
@@ -275,7 +343,8 @@ class _$_Start implements _Start {
     final String? $type,
   }) : $type = $type ?? 'start';
 
-  factory _$_Start.fromJson(Map<String, dynamic> json) => _$$_StartFromJson(json);
+  factory _$StartImpl.fromJson(Map<String, dynamic> json) =>
+      _$$StartImplFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -307,34 +376,41 @@ class _$_Start implements _Start {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Start &&
-            const DeepCollectionEquality().equals(other.time, time) &&
-            const DeepCollectionEquality().equals(other.protocolVersion, protocolVersion) &&
-            const DeepCollectionEquality().equals(other.runnerVersion, runnerVersion) &&
-            const DeepCollectionEquality().equals(other.pid, pid));
+            other is _$StartImpl &&
+            (identical(other.time, time) || other.time == time) &&
+            (identical(other.protocolVersion, protocolVersion) ||
+                other.protocolVersion == protocolVersion) &&
+            (identical(other.runnerVersion, runnerVersion) ||
+                other.runnerVersion == runnerVersion) &&
+            (identical(other.pid, pid) || other.pid == pid));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(
-    runtimeType,
-    const DeepCollectionEquality().hash(time),
-    const DeepCollectionEquality().hash(protocolVersion),
-    const DeepCollectionEquality().hash(runnerVersion),
-    const DeepCollectionEquality().hash(pid),
-  );
+  int get hashCode =>
+      Object.hash(runtimeType, time, protocolVersion, runnerVersion, pid);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  _$$_StartCopyWith<_$_Start> get copyWith => __$$_StartCopyWithImpl<_$_Start>(this, _$identity);
+  @pragma('vm:prefer-inline')
+  _$$StartImplCopyWith<_$StartImpl> get copyWith =>
+      __$$StartImplCopyWithImpl<_$StartImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
+    required TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )
+    start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -346,7 +422,13 @@ class _$_Start implements _Start {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )
+    print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -372,15 +454,32 @@ class _$_Start implements _Start {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
-    TResult Function(int time, int count)? allSuites,
-    TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult? Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
+    TResult? Function(int time, int count)? allSuites,
+    TResult? Function(int time, Suite suite)? suite,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
-    TResult Function(int time, Group group)? group,
-    TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
-    TResult Function(
+    TResult? Function(int time, Group group)? group,
+    TResult? Function(int time, Test test)? testStart,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
+    TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
       String error,
@@ -388,7 +487,7 @@ class _$_Start implements _Start {
       bool isFailure,
     )?
     error,
-    TResult Function(
+    TResult? Function(
       int time,
       @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
       @JsonKey(name: 'testID') int testId,
@@ -396,8 +495,8 @@ class _$_Start implements _Start {
       bool skipped,
     )?
     testDone,
-    TResult Function(int time, bool? success)? done,
-    TResult Function(int time)? unknown,
+    TResult? Function(int time, bool? success)? done,
+    TResult? Function(int time)? unknown,
   }) {
     return start?.call(time, protocolVersion, runnerVersion, pid);
   }
@@ -405,14 +504,31 @@ class _$_Start implements _Start {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -460,17 +576,17 @@ class _$_Start implements _Start {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult Function(_Start value)? start,
-    TResult Function(_AllSuites value)? allSuites,
-    TResult Function(_Suite value)? suite,
-    TResult Function(_Debug value)? debug,
-    TResult Function(_Group value)? group,
-    TResult Function(_TestStart value)? testStart,
-    TResult Function(_Print value)? print,
-    TResult Function(_Error value)? error,
-    TResult Function(_TestDone value)? testDone,
-    TResult Function(_Done value)? done,
-    TResult Function(_Unknown value)? unknown,
+    TResult? Function(_Start value)? start,
+    TResult? Function(_AllSuites value)? allSuites,
+    TResult? Function(_Suite value)? suite,
+    TResult? Function(_Debug value)? debug,
+    TResult? Function(_Group value)? group,
+    TResult? Function(_TestStart value)? testStart,
+    TResult? Function(_Print value)? print,
+    TResult? Function(_Error value)? error,
+    TResult? Function(_TestDone value)? testDone,
+    TResult? Function(_Done value)? done,
+    TResult? Function(_Unknown value)? unknown,
   }) {
     return start?.call(this);
   }
@@ -499,7 +615,7 @@ class _$_Start implements _Start {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_StartToJson(this);
+    return _$$StartImplToJson(this);
   }
 }
 
@@ -509,12 +625,12 @@ abstract class _Start implements Event {
     required final String protocolVersion,
     final String? runnerVersion,
     required final int pid,
-  }) = _$_Start;
+  }) = _$StartImpl;
 
-  factory _Start.fromJson(Map<String, dynamic> json) = _$_Start.fromJson;
+  factory _Start.fromJson(Map<String, dynamic> json) = _$StartImpl.fromJson;
 
-  @override
   /// The time (in milliseconds) that has elapsed since the test runner started.
+  @override
   int get time;
 
   /// The version of the JSON reporter protocol being used.
@@ -530,38 +646,49 @@ abstract class _Start implements Event {
 
   /// The pid of the VM process running the tests.
   int get pid;
+
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
-  _$$_StartCopyWith<_$_Start> get copyWith => throw _privateConstructorUsedError;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$StartImplCopyWith<_$StartImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$_AllSuitesCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$_AllSuitesCopyWith(_$_AllSuites value, $Res Function(_$_AllSuites) then) =
-      __$$_AllSuitesCopyWithImpl<$Res>;
+abstract class _$$AllSuitesImplCopyWith<$Res> implements $EventCopyWith<$Res> {
+  factory _$$AllSuitesImplCopyWith(
+    _$AllSuitesImpl value,
+    $Res Function(_$AllSuitesImpl) then,
+  ) = __$$AllSuitesImplCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call({int time, int count});
 }
 
 /// @nodoc
-class __$$_AllSuitesCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> implements _$$_AllSuitesCopyWith<$Res> {
-  __$$_AllSuitesCopyWithImpl(_$_AllSuites _value, $Res Function(_$_AllSuites) _then)
-    : super(_value, (v) => _then(v as _$_AllSuites));
+class __$$AllSuitesImplCopyWithImpl<$Res>
+    extends _$EventCopyWithImpl<$Res, _$AllSuitesImpl>
+    implements _$$AllSuitesImplCopyWith<$Res> {
+  __$$AllSuitesImplCopyWithImpl(
+    _$AllSuitesImpl _value,
+    $Res Function(_$AllSuitesImpl) _then,
+  ) : super(_value, _then);
 
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
   @override
-  _$_AllSuites get _value => super._value as _$_AllSuites;
-
-  @override
-  $Res call({Object? time = freezed, Object? count = freezed}) {
+  $Res call({Object? time = null, Object? count = null}) {
     return _then(
-      _$_AllSuites(
+      _$AllSuitesImpl(
         time:
-            time == freezed
+            null == time
                 ? _value.time
                 : time // ignore: cast_nullable_to_non_nullable
                     as int,
         count:
-            count == freezed
+            null == count
                 ? _value.count
                 : count // ignore: cast_nullable_to_non_nullable
                     as int,
@@ -572,10 +699,15 @@ class __$$_AllSuitesCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> impleme
 
 /// @nodoc
 @JsonSerializable()
-class _$_AllSuites implements _AllSuites {
-  const _$_AllSuites({required this.time, required this.count, final String? $type}) : $type = $type ?? 'allSuites';
+class _$AllSuitesImpl implements _AllSuites {
+  const _$AllSuitesImpl({
+    required this.time,
+    required this.count,
+    final String? $type,
+  }) : $type = $type ?? 'allSuites';
 
-  factory _$_AllSuites.fromJson(Map<String, dynamic> json) => _$$_AllSuitesFromJson(json);
+  factory _$AllSuitesImpl.fromJson(Map<String, dynamic> json) =>
+      _$$AllSuitesImplFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -594,27 +726,36 @@ class _$_AllSuites implements _AllSuites {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_AllSuites &&
-            const DeepCollectionEquality().equals(other.time, time) &&
-            const DeepCollectionEquality().equals(other.count, count));
+            other is _$AllSuitesImpl &&
+            (identical(other.time, time) || other.time == time) &&
+            (identical(other.count, count) || other.count == count));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(time), const DeepCollectionEquality().hash(count));
+  int get hashCode => Object.hash(runtimeType, time, count);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  _$$_AllSuitesCopyWith<_$_AllSuites> get copyWith => __$$_AllSuitesCopyWithImpl<_$_AllSuites>(this, _$identity);
+  @pragma('vm:prefer-inline')
+  _$$AllSuitesImplCopyWith<_$AllSuitesImpl> get copyWith =>
+      __$$AllSuitesImplCopyWithImpl<_$AllSuitesImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
+    required TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )
+    start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -626,7 +767,13 @@ class _$_AllSuites implements _AllSuites {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )
+    print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -652,15 +799,32 @@ class _$_AllSuites implements _AllSuites {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
-    TResult Function(int time, int count)? allSuites,
-    TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult? Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
+    TResult? Function(int time, int count)? allSuites,
+    TResult? Function(int time, Suite suite)? suite,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
-    TResult Function(int time, Group group)? group,
-    TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
-    TResult Function(
+    TResult? Function(int time, Group group)? group,
+    TResult? Function(int time, Test test)? testStart,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
+    TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
       String error,
@@ -668,7 +832,7 @@ class _$_AllSuites implements _AllSuites {
       bool isFailure,
     )?
     error,
-    TResult Function(
+    TResult? Function(
       int time,
       @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
       @JsonKey(name: 'testID') int testId,
@@ -676,8 +840,8 @@ class _$_AllSuites implements _AllSuites {
       bool skipped,
     )?
     testDone,
-    TResult Function(int time, bool? success)? done,
-    TResult Function(int time)? unknown,
+    TResult? Function(int time, bool? success)? done,
+    TResult? Function(int time)? unknown,
   }) {
     return allSuites?.call(time, count);
   }
@@ -685,14 +849,31 @@ class _$_AllSuites implements _AllSuites {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -740,17 +921,17 @@ class _$_AllSuites implements _AllSuites {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult Function(_Start value)? start,
-    TResult Function(_AllSuites value)? allSuites,
-    TResult Function(_Suite value)? suite,
-    TResult Function(_Debug value)? debug,
-    TResult Function(_Group value)? group,
-    TResult Function(_TestStart value)? testStart,
-    TResult Function(_Print value)? print,
-    TResult Function(_Error value)? error,
-    TResult Function(_TestDone value)? testDone,
-    TResult Function(_Done value)? done,
-    TResult Function(_Unknown value)? unknown,
+    TResult? Function(_Start value)? start,
+    TResult? Function(_AllSuites value)? allSuites,
+    TResult? Function(_Suite value)? suite,
+    TResult? Function(_Debug value)? debug,
+    TResult? Function(_Group value)? group,
+    TResult? Function(_TestStart value)? testStart,
+    TResult? Function(_Print value)? print,
+    TResult? Function(_Error value)? error,
+    TResult? Function(_TestDone value)? testDone,
+    TResult? Function(_Done value)? done,
+    TResult? Function(_Unknown value)? unknown,
   }) {
     return allSuites?.call(this);
   }
@@ -779,53 +960,70 @@ class _$_AllSuites implements _AllSuites {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_AllSuitesToJson(this);
+    return _$$AllSuitesImplToJson(this);
   }
 }
 
 abstract class _AllSuites implements Event {
-  const factory _AllSuites({required final int time, required final int count}) = _$_AllSuites;
+  const factory _AllSuites({
+    required final int time,
+    required final int count,
+  }) = _$AllSuitesImpl;
 
-  factory _AllSuites.fromJson(Map<String, dynamic> json) = _$_AllSuites.fromJson;
+  factory _AllSuites.fromJson(Map<String, dynamic> json) =
+      _$AllSuitesImpl.fromJson;
 
-  @override
   /// The time (in milliseconds) that has elapsed since the test runner started.
+  @override
   int get time;
 
   /// The total number of suites that will be loaded.
   int get count;
+
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
-  _$$_AllSuitesCopyWith<_$_AllSuites> get copyWith => throw _privateConstructorUsedError;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$AllSuitesImplCopyWith<_$AllSuitesImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$_SuiteCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$_SuiteCopyWith(_$_Suite value, $Res Function(_$_Suite) then) = __$$_SuiteCopyWithImpl<$Res>;
+abstract class _$$SuiteImplCopyWith<$Res> implements $EventCopyWith<$Res> {
+  factory _$$SuiteImplCopyWith(
+    _$SuiteImpl value,
+    $Res Function(_$SuiteImpl) then,
+  ) = __$$SuiteImplCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call({int time, Suite suite});
 
   $SuiteCopyWith<$Res> get suite;
 }
 
 /// @nodoc
-class __$$_SuiteCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> implements _$$_SuiteCopyWith<$Res> {
-  __$$_SuiteCopyWithImpl(_$_Suite _value, $Res Function(_$_Suite) _then) : super(_value, (v) => _then(v as _$_Suite));
+class __$$SuiteImplCopyWithImpl<$Res>
+    extends _$EventCopyWithImpl<$Res, _$SuiteImpl>
+    implements _$$SuiteImplCopyWith<$Res> {
+  __$$SuiteImplCopyWithImpl(
+    _$SuiteImpl _value,
+    $Res Function(_$SuiteImpl) _then,
+  ) : super(_value, _then);
 
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
   @override
-  _$_Suite get _value => super._value as _$_Suite;
-
-  @override
-  $Res call({Object? time = freezed, Object? suite = freezed}) {
+  $Res call({Object? time = null, Object? suite = null}) {
     return _then(
-      _$_Suite(
+      _$SuiteImpl(
         time:
-            time == freezed
+            null == time
                 ? _value.time
                 : time // ignore: cast_nullable_to_non_nullable
                     as int,
         suite:
-            suite == freezed
+            null == suite
                 ? _value.suite
                 : suite // ignore: cast_nullable_to_non_nullable
                     as Suite,
@@ -833,7 +1031,10 @@ class __$$_SuiteCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> implements 
     );
   }
 
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
   @override
+  @pragma('vm:prefer-inline')
   $SuiteCopyWith<$Res> get suite {
     return $SuiteCopyWith<$Res>(_value.suite, (value) {
       return _then(_value.copyWith(suite: value));
@@ -843,10 +1044,15 @@ class __$$_SuiteCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> implements 
 
 /// @nodoc
 @JsonSerializable()
-class _$_Suite implements _Suite {
-  const _$_Suite({required this.time, required this.suite, final String? $type}) : $type = $type ?? 'suite';
+class _$SuiteImpl implements _Suite {
+  const _$SuiteImpl({
+    required this.time,
+    required this.suite,
+    final String? $type,
+  }) : $type = $type ?? 'suite';
 
-  factory _$_Suite.fromJson(Map<String, dynamic> json) => _$$_SuiteFromJson(json);
+  factory _$SuiteImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SuiteImplFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -865,27 +1071,36 @@ class _$_Suite implements _Suite {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Suite &&
-            const DeepCollectionEquality().equals(other.time, time) &&
-            const DeepCollectionEquality().equals(other.suite, suite));
+            other is _$SuiteImpl &&
+            (identical(other.time, time) || other.time == time) &&
+            (identical(other.suite, suite) || other.suite == suite));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(time), const DeepCollectionEquality().hash(suite));
+  int get hashCode => Object.hash(runtimeType, time, suite);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  _$$_SuiteCopyWith<_$_Suite> get copyWith => __$$_SuiteCopyWithImpl<_$_Suite>(this, _$identity);
+  @pragma('vm:prefer-inline')
+  _$$SuiteImplCopyWith<_$SuiteImpl> get copyWith =>
+      __$$SuiteImplCopyWithImpl<_$SuiteImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
+    required TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )
+    start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -897,7 +1112,13 @@ class _$_Suite implements _Suite {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )
+    print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -923,15 +1144,32 @@ class _$_Suite implements _Suite {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
-    TResult Function(int time, int count)? allSuites,
-    TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult? Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
+    TResult? Function(int time, int count)? allSuites,
+    TResult? Function(int time, Suite suite)? suite,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
-    TResult Function(int time, Group group)? group,
-    TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
-    TResult Function(
+    TResult? Function(int time, Group group)? group,
+    TResult? Function(int time, Test test)? testStart,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
+    TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
       String error,
@@ -939,7 +1177,7 @@ class _$_Suite implements _Suite {
       bool isFailure,
     )?
     error,
-    TResult Function(
+    TResult? Function(
       int time,
       @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
       @JsonKey(name: 'testID') int testId,
@@ -947,8 +1185,8 @@ class _$_Suite implements _Suite {
       bool skipped,
     )?
     testDone,
-    TResult Function(int time, bool? success)? done,
-    TResult Function(int time)? unknown,
+    TResult? Function(int time, bool? success)? done,
+    TResult? Function(int time)? unknown,
   }) {
     return suite?.call(time, this.suite);
   }
@@ -956,14 +1194,31 @@ class _$_Suite implements _Suite {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -1011,17 +1266,17 @@ class _$_Suite implements _Suite {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult Function(_Start value)? start,
-    TResult Function(_AllSuites value)? allSuites,
-    TResult Function(_Suite value)? suite,
-    TResult Function(_Debug value)? debug,
-    TResult Function(_Group value)? group,
-    TResult Function(_TestStart value)? testStart,
-    TResult Function(_Print value)? print,
-    TResult Function(_Error value)? error,
-    TResult Function(_TestDone value)? testDone,
-    TResult Function(_Done value)? done,
-    TResult Function(_Unknown value)? unknown,
+    TResult? Function(_Start value)? start,
+    TResult? Function(_AllSuites value)? allSuites,
+    TResult? Function(_Suite value)? suite,
+    TResult? Function(_Debug value)? debug,
+    TResult? Function(_Group value)? group,
+    TResult? Function(_TestStart value)? testStart,
+    TResult? Function(_Print value)? print,
+    TResult? Function(_Error value)? error,
+    TResult? Function(_TestDone value)? testDone,
+    TResult? Function(_Done value)? done,
+    TResult? Function(_Unknown value)? unknown,
   }) {
     return suite?.call(this);
   }
@@ -1050,66 +1305,85 @@ class _$_Suite implements _Suite {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_SuiteToJson(this);
+    return _$$SuiteImplToJson(this);
   }
 }
 
 abstract class _Suite implements Event {
-  const factory _Suite({required final int time, required final Suite suite}) = _$_Suite;
+  const factory _Suite({required final int time, required final Suite suite}) =
+      _$SuiteImpl;
 
-  factory _Suite.fromJson(Map<String, dynamic> json) = _$_Suite.fromJson;
+  factory _Suite.fromJson(Map<String, dynamic> json) = _$SuiteImpl.fromJson;
 
-  @override
   /// The time (in milliseconds) that has elapsed since the test runner started.
+  @override
   int get time;
 
   /// Metadata about the Suite.
   Suite get suite;
+
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
-  _$$_SuiteCopyWith<_$_Suite> get copyWith => throw _privateConstructorUsedError;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$SuiteImplCopyWith<_$SuiteImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$_DebugCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$_DebugCopyWith(_$_Debug value, $Res Function(_$_Debug) then) = __$$_DebugCopyWithImpl<$Res>;
+abstract class _$$DebugImplCopyWith<$Res> implements $EventCopyWith<$Res> {
+  factory _$$DebugImplCopyWith(
+    _$DebugImpl value,
+    $Res Function(_$DebugImpl) then,
+  ) = __$$DebugImplCopyWithImpl<$Res>;
   @override
-  $Res call({int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger});
+  @useResult
+  $Res call({
+    int time,
+    @JsonKey(name: 'suiteID') int suiteId,
+    String? observatory,
+    String? remoteDebugger,
+  });
 }
 
 /// @nodoc
-class __$$_DebugCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> implements _$$_DebugCopyWith<$Res> {
-  __$$_DebugCopyWithImpl(_$_Debug _value, $Res Function(_$_Debug) _then) : super(_value, (v) => _then(v as _$_Debug));
+class __$$DebugImplCopyWithImpl<$Res>
+    extends _$EventCopyWithImpl<$Res, _$DebugImpl>
+    implements _$$DebugImplCopyWith<$Res> {
+  __$$DebugImplCopyWithImpl(
+    _$DebugImpl _value,
+    $Res Function(_$DebugImpl) _then,
+  ) : super(_value, _then);
 
-  @override
-  _$_Debug get _value => super._value as _$_Debug;
-
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? time = freezed,
-    Object? suiteId = freezed,
+    Object? time = null,
+    Object? suiteId = null,
     Object? observatory = freezed,
     Object? remoteDebugger = freezed,
   }) {
     return _then(
-      _$_Debug(
+      _$DebugImpl(
         time:
-            time == freezed
+            null == time
                 ? _value.time
                 : time // ignore: cast_nullable_to_non_nullable
                     as int,
         suiteId:
-            suiteId == freezed
+            null == suiteId
                 ? _value.suiteId
                 : suiteId // ignore: cast_nullable_to_non_nullable
                     as int,
         observatory:
-            observatory == freezed
+            freezed == observatory
                 ? _value.observatory
                 : observatory // ignore: cast_nullable_to_non_nullable
                     as String?,
         remoteDebugger:
-            remoteDebugger == freezed
+            freezed == remoteDebugger
                 ? _value.remoteDebugger
                 : remoteDebugger // ignore: cast_nullable_to_non_nullable
                     as String?,
@@ -1120,8 +1394,8 @@ class __$$_DebugCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> implements 
 
 /// @nodoc
 @JsonSerializable()
-class _$_Debug implements _Debug {
-  const _$_Debug({
+class _$DebugImpl implements _Debug {
+  const _$DebugImpl({
     required this.time,
     @JsonKey(name: 'suiteID') required this.suiteId,
     this.observatory,
@@ -1129,7 +1403,8 @@ class _$_Debug implements _Debug {
     final String? $type,
   }) : $type = $type ?? 'debug';
 
-  factory _$_Debug.fromJson(Map<String, dynamic> json) => _$$_DebugFromJson(json);
+  factory _$DebugImpl.fromJson(Map<String, dynamic> json) =>
+      _$$DebugImplFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -1157,34 +1432,41 @@ class _$_Debug implements _Debug {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Debug &&
-            const DeepCollectionEquality().equals(other.time, time) &&
-            const DeepCollectionEquality().equals(other.suiteId, suiteId) &&
-            const DeepCollectionEquality().equals(other.observatory, observatory) &&
-            const DeepCollectionEquality().equals(other.remoteDebugger, remoteDebugger));
+            other is _$DebugImpl &&
+            (identical(other.time, time) || other.time == time) &&
+            (identical(other.suiteId, suiteId) || other.suiteId == suiteId) &&
+            (identical(other.observatory, observatory) ||
+                other.observatory == observatory) &&
+            (identical(other.remoteDebugger, remoteDebugger) ||
+                other.remoteDebugger == remoteDebugger));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(
-    runtimeType,
-    const DeepCollectionEquality().hash(time),
-    const DeepCollectionEquality().hash(suiteId),
-    const DeepCollectionEquality().hash(observatory),
-    const DeepCollectionEquality().hash(remoteDebugger),
-  );
+  int get hashCode =>
+      Object.hash(runtimeType, time, suiteId, observatory, remoteDebugger);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  _$$_DebugCopyWith<_$_Debug> get copyWith => __$$_DebugCopyWithImpl<_$_Debug>(this, _$identity);
+  @pragma('vm:prefer-inline')
+  _$$DebugImplCopyWith<_$DebugImpl> get copyWith =>
+      __$$DebugImplCopyWithImpl<_$DebugImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
+    required TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )
+    start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -1196,7 +1478,13 @@ class _$_Debug implements _Debug {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )
+    print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -1222,15 +1510,32 @@ class _$_Debug implements _Debug {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
-    TResult Function(int time, int count)? allSuites,
-    TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult? Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
+    TResult? Function(int time, int count)? allSuites,
+    TResult? Function(int time, Suite suite)? suite,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
-    TResult Function(int time, Group group)? group,
-    TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
-    TResult Function(
+    TResult? Function(int time, Group group)? group,
+    TResult? Function(int time, Test test)? testStart,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
+    TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
       String error,
@@ -1238,7 +1543,7 @@ class _$_Debug implements _Debug {
       bool isFailure,
     )?
     error,
-    TResult Function(
+    TResult? Function(
       int time,
       @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
       @JsonKey(name: 'testID') int testId,
@@ -1246,8 +1551,8 @@ class _$_Debug implements _Debug {
       bool skipped,
     )?
     testDone,
-    TResult Function(int time, bool? success)? done,
-    TResult Function(int time)? unknown,
+    TResult? Function(int time, bool? success)? done,
+    TResult? Function(int time)? unknown,
   }) {
     return debug?.call(time, suiteId, observatory, remoteDebugger);
   }
@@ -1255,14 +1560,31 @@ class _$_Debug implements _Debug {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -1310,17 +1632,17 @@ class _$_Debug implements _Debug {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult Function(_Start value)? start,
-    TResult Function(_AllSuites value)? allSuites,
-    TResult Function(_Suite value)? suite,
-    TResult Function(_Debug value)? debug,
-    TResult Function(_Group value)? group,
-    TResult Function(_TestStart value)? testStart,
-    TResult Function(_Print value)? print,
-    TResult Function(_Error value)? error,
-    TResult Function(_TestDone value)? testDone,
-    TResult Function(_Done value)? done,
-    TResult Function(_Unknown value)? unknown,
+    TResult? Function(_Start value)? start,
+    TResult? Function(_AllSuites value)? allSuites,
+    TResult? Function(_Suite value)? suite,
+    TResult? Function(_Debug value)? debug,
+    TResult? Function(_Group value)? group,
+    TResult? Function(_TestStart value)? testStart,
+    TResult? Function(_Print value)? print,
+    TResult? Function(_Error value)? error,
+    TResult? Function(_TestDone value)? testDone,
+    TResult? Function(_Done value)? done,
+    TResult? Function(_Unknown value)? unknown,
   }) {
     return debug?.call(this);
   }
@@ -1349,7 +1671,7 @@ class _$_Debug implements _Debug {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_DebugToJson(this);
+    return _$$DebugImplToJson(this);
   }
 }
 
@@ -1359,12 +1681,12 @@ abstract class _Debug implements Event {
     @JsonKey(name: 'suiteID') required final int suiteId,
     final String? observatory,
     final String? remoteDebugger,
-  }) = _$_Debug;
+  }) = _$DebugImpl;
 
-  factory _Debug.fromJson(Map<String, dynamic> json) = _$_Debug.fromJson;
+  factory _Debug.fromJson(Map<String, dynamic> json) = _$DebugImpl.fromJson;
 
-  @override
   /// The time (in milliseconds) that has elapsed since the test runner started.
+  @override
   int get time;
 
   /// The suite for which debug information is reported.
@@ -1376,38 +1698,51 @@ abstract class _Debug implements Event {
 
   /// The HTTP URL for the remote debugger for this suite's host page, or `null` if no remote debugger is available for this suite.
   String? get remoteDebugger;
+
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
-  _$$_DebugCopyWith<_$_Debug> get copyWith => throw _privateConstructorUsedError;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$DebugImplCopyWith<_$DebugImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$_GroupCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$_GroupCopyWith(_$_Group value, $Res Function(_$_Group) then) = __$$_GroupCopyWithImpl<$Res>;
+abstract class _$$GroupImplCopyWith<$Res> implements $EventCopyWith<$Res> {
+  factory _$$GroupImplCopyWith(
+    _$GroupImpl value,
+    $Res Function(_$GroupImpl) then,
+  ) = __$$GroupImplCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call({int time, Group group});
 
   $GroupCopyWith<$Res> get group;
 }
 
 /// @nodoc
-class __$$_GroupCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> implements _$$_GroupCopyWith<$Res> {
-  __$$_GroupCopyWithImpl(_$_Group _value, $Res Function(_$_Group) _then) : super(_value, (v) => _then(v as _$_Group));
+class __$$GroupImplCopyWithImpl<$Res>
+    extends _$EventCopyWithImpl<$Res, _$GroupImpl>
+    implements _$$GroupImplCopyWith<$Res> {
+  __$$GroupImplCopyWithImpl(
+    _$GroupImpl _value,
+    $Res Function(_$GroupImpl) _then,
+  ) : super(_value, _then);
 
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
   @override
-  _$_Group get _value => super._value as _$_Group;
-
-  @override
-  $Res call({Object? time = freezed, Object? group = freezed}) {
+  $Res call({Object? time = null, Object? group = null}) {
     return _then(
-      _$_Group(
+      _$GroupImpl(
         time:
-            time == freezed
+            null == time
                 ? _value.time
                 : time // ignore: cast_nullable_to_non_nullable
                     as int,
         group:
-            group == freezed
+            null == group
                 ? _value.group
                 : group // ignore: cast_nullable_to_non_nullable
                     as Group,
@@ -1415,7 +1750,10 @@ class __$$_GroupCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> implements 
     );
   }
 
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
   @override
+  @pragma('vm:prefer-inline')
   $GroupCopyWith<$Res> get group {
     return $GroupCopyWith<$Res>(_value.group, (value) {
       return _then(_value.copyWith(group: value));
@@ -1425,10 +1763,15 @@ class __$$_GroupCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> implements 
 
 /// @nodoc
 @JsonSerializable()
-class _$_Group implements _Group {
-  const _$_Group({required this.time, required this.group, final String? $type}) : $type = $type ?? 'group';
+class _$GroupImpl implements _Group {
+  const _$GroupImpl({
+    required this.time,
+    required this.group,
+    final String? $type,
+  }) : $type = $type ?? 'group';
 
-  factory _$_Group.fromJson(Map<String, dynamic> json) => _$$_GroupFromJson(json);
+  factory _$GroupImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GroupImplFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -1447,27 +1790,36 @@ class _$_Group implements _Group {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Group &&
-            const DeepCollectionEquality().equals(other.time, time) &&
-            const DeepCollectionEquality().equals(other.group, group));
+            other is _$GroupImpl &&
+            (identical(other.time, time) || other.time == time) &&
+            (identical(other.group, group) || other.group == group));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(time), const DeepCollectionEquality().hash(group));
+  int get hashCode => Object.hash(runtimeType, time, group);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  _$$_GroupCopyWith<_$_Group> get copyWith => __$$_GroupCopyWithImpl<_$_Group>(this, _$identity);
+  @pragma('vm:prefer-inline')
+  _$$GroupImplCopyWith<_$GroupImpl> get copyWith =>
+      __$$GroupImplCopyWithImpl<_$GroupImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
+    required TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )
+    start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -1479,7 +1831,13 @@ class _$_Group implements _Group {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )
+    print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -1505,15 +1863,32 @@ class _$_Group implements _Group {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
-    TResult Function(int time, int count)? allSuites,
-    TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult? Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
+    TResult? Function(int time, int count)? allSuites,
+    TResult? Function(int time, Suite suite)? suite,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
-    TResult Function(int time, Group group)? group,
-    TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
-    TResult Function(
+    TResult? Function(int time, Group group)? group,
+    TResult? Function(int time, Test test)? testStart,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
+    TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
       String error,
@@ -1521,7 +1896,7 @@ class _$_Group implements _Group {
       bool isFailure,
     )?
     error,
-    TResult Function(
+    TResult? Function(
       int time,
       @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
       @JsonKey(name: 'testID') int testId,
@@ -1529,8 +1904,8 @@ class _$_Group implements _Group {
       bool skipped,
     )?
     testDone,
-    TResult Function(int time, bool? success)? done,
-    TResult Function(int time)? unknown,
+    TResult? Function(int time, bool? success)? done,
+    TResult? Function(int time)? unknown,
   }) {
     return group?.call(time, this.group);
   }
@@ -1538,14 +1913,31 @@ class _$_Group implements _Group {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -1593,17 +1985,17 @@ class _$_Group implements _Group {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult Function(_Start value)? start,
-    TResult Function(_AllSuites value)? allSuites,
-    TResult Function(_Suite value)? suite,
-    TResult Function(_Debug value)? debug,
-    TResult Function(_Group value)? group,
-    TResult Function(_TestStart value)? testStart,
-    TResult Function(_Print value)? print,
-    TResult Function(_Error value)? error,
-    TResult Function(_TestDone value)? testDone,
-    TResult Function(_Done value)? done,
-    TResult Function(_Unknown value)? unknown,
+    TResult? Function(_Start value)? start,
+    TResult? Function(_AllSuites value)? allSuites,
+    TResult? Function(_Suite value)? suite,
+    TResult? Function(_Debug value)? debug,
+    TResult? Function(_Group value)? group,
+    TResult? Function(_TestStart value)? testStart,
+    TResult? Function(_Print value)? print,
+    TResult? Function(_Error value)? error,
+    TResult? Function(_TestDone value)? testDone,
+    TResult? Function(_Done value)? done,
+    TResult? Function(_Unknown value)? unknown,
   }) {
     return group?.call(this);
   }
@@ -1632,55 +2024,67 @@ class _$_Group implements _Group {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GroupToJson(this);
+    return _$$GroupImplToJson(this);
   }
 }
 
 abstract class _Group implements Event {
-  const factory _Group({required final int time, required final Group group}) = _$_Group;
+  const factory _Group({required final int time, required final Group group}) =
+      _$GroupImpl;
 
-  factory _Group.fromJson(Map<String, dynamic> json) = _$_Group.fromJson;
+  factory _Group.fromJson(Map<String, dynamic> json) = _$GroupImpl.fromJson;
 
-  @override
   /// The time (in milliseconds) that has elapsed since the test runner started.
+  @override
   int get time;
 
   /// Metadata about the Group.
   Group get group;
+
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
-  _$$_GroupCopyWith<_$_Group> get copyWith => throw _privateConstructorUsedError;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$GroupImplCopyWith<_$GroupImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$_TestStartCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$_TestStartCopyWith(_$_TestStart value, $Res Function(_$_TestStart) then) =
-      __$$_TestStartCopyWithImpl<$Res>;
+abstract class _$$TestStartImplCopyWith<$Res> implements $EventCopyWith<$Res> {
+  factory _$$TestStartImplCopyWith(
+    _$TestStartImpl value,
+    $Res Function(_$TestStartImpl) then,
+  ) = __$$TestStartImplCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call({int time, Test test});
 
   $TestCopyWith<$Res> get test;
 }
 
 /// @nodoc
-class __$$_TestStartCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> implements _$$_TestStartCopyWith<$Res> {
-  __$$_TestStartCopyWithImpl(_$_TestStart _value, $Res Function(_$_TestStart) _then)
-    : super(_value, (v) => _then(v as _$_TestStart));
+class __$$TestStartImplCopyWithImpl<$Res>
+    extends _$EventCopyWithImpl<$Res, _$TestStartImpl>
+    implements _$$TestStartImplCopyWith<$Res> {
+  __$$TestStartImplCopyWithImpl(
+    _$TestStartImpl _value,
+    $Res Function(_$TestStartImpl) _then,
+  ) : super(_value, _then);
 
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
   @override
-  _$_TestStart get _value => super._value as _$_TestStart;
-
-  @override
-  $Res call({Object? time = freezed, Object? test = freezed}) {
+  $Res call({Object? time = null, Object? test = null}) {
     return _then(
-      _$_TestStart(
+      _$TestStartImpl(
         time:
-            time == freezed
+            null == time
                 ? _value.time
                 : time // ignore: cast_nullable_to_non_nullable
                     as int,
         test:
-            test == freezed
+            null == test
                 ? _value.test
                 : test // ignore: cast_nullable_to_non_nullable
                     as Test,
@@ -1688,7 +2092,10 @@ class __$$_TestStartCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> impleme
     );
   }
 
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
   @override
+  @pragma('vm:prefer-inline')
   $TestCopyWith<$Res> get test {
     return $TestCopyWith<$Res>(_value.test, (value) {
       return _then(_value.copyWith(test: value));
@@ -1698,10 +2105,15 @@ class __$$_TestStartCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> impleme
 
 /// @nodoc
 @JsonSerializable()
-class _$_TestStart implements _TestStart {
-  const _$_TestStart({required this.time, required this.test, final String? $type}) : $type = $type ?? 'testStart';
+class _$TestStartImpl implements _TestStart {
+  const _$TestStartImpl({
+    required this.time,
+    required this.test,
+    final String? $type,
+  }) : $type = $type ?? 'testStart';
 
-  factory _$_TestStart.fromJson(Map<String, dynamic> json) => _$$_TestStartFromJson(json);
+  factory _$TestStartImpl.fromJson(Map<String, dynamic> json) =>
+      _$$TestStartImplFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -1720,27 +2132,36 @@ class _$_TestStart implements _TestStart {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_TestStart &&
-            const DeepCollectionEquality().equals(other.time, time) &&
-            const DeepCollectionEquality().equals(other.test, test));
+            other is _$TestStartImpl &&
+            (identical(other.time, time) || other.time == time) &&
+            (identical(other.test, test) || other.test == test));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(time), const DeepCollectionEquality().hash(test));
+  int get hashCode => Object.hash(runtimeType, time, test);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  _$$_TestStartCopyWith<_$_TestStart> get copyWith => __$$_TestStartCopyWithImpl<_$_TestStart>(this, _$identity);
+  @pragma('vm:prefer-inline')
+  _$$TestStartImplCopyWith<_$TestStartImpl> get copyWith =>
+      __$$TestStartImplCopyWithImpl<_$TestStartImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
+    required TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )
+    start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -1752,7 +2173,13 @@ class _$_TestStart implements _TestStart {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )
+    print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -1778,15 +2205,32 @@ class _$_TestStart implements _TestStart {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
-    TResult Function(int time, int count)? allSuites,
-    TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult? Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
+    TResult? Function(int time, int count)? allSuites,
+    TResult? Function(int time, Suite suite)? suite,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
-    TResult Function(int time, Group group)? group,
-    TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
-    TResult Function(
+    TResult? Function(int time, Group group)? group,
+    TResult? Function(int time, Test test)? testStart,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
+    TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
       String error,
@@ -1794,7 +2238,7 @@ class _$_TestStart implements _TestStart {
       bool isFailure,
     )?
     error,
-    TResult Function(
+    TResult? Function(
       int time,
       @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
       @JsonKey(name: 'testID') int testId,
@@ -1802,8 +2246,8 @@ class _$_TestStart implements _TestStart {
       bool skipped,
     )?
     testDone,
-    TResult Function(int time, bool? success)? done,
-    TResult Function(int time)? unknown,
+    TResult? Function(int time, bool? success)? done,
+    TResult? Function(int time)? unknown,
   }) {
     return testStart?.call(time, test);
   }
@@ -1811,14 +2255,31 @@ class _$_TestStart implements _TestStart {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -1866,17 +2327,17 @@ class _$_TestStart implements _TestStart {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult Function(_Start value)? start,
-    TResult Function(_AllSuites value)? allSuites,
-    TResult Function(_Suite value)? suite,
-    TResult Function(_Debug value)? debug,
-    TResult Function(_Group value)? group,
-    TResult Function(_TestStart value)? testStart,
-    TResult Function(_Print value)? print,
-    TResult Function(_Error value)? error,
-    TResult Function(_TestDone value)? testDone,
-    TResult Function(_Done value)? done,
-    TResult Function(_Unknown value)? unknown,
+    TResult? Function(_Start value)? start,
+    TResult? Function(_AllSuites value)? allSuites,
+    TResult? Function(_Suite value)? suite,
+    TResult? Function(_Debug value)? debug,
+    TResult? Function(_Group value)? group,
+    TResult? Function(_TestStart value)? testStart,
+    TResult? Function(_Print value)? print,
+    TResult? Function(_Error value)? error,
+    TResult? Function(_TestDone value)? testDone,
+    TResult? Function(_Done value)? done,
+    TResult? Function(_Unknown value)? unknown,
   }) {
     return testStart?.call(this);
   }
@@ -1905,66 +2366,88 @@ class _$_TestStart implements _TestStart {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_TestStartToJson(this);
+    return _$$TestStartImplToJson(this);
   }
 }
 
 abstract class _TestStart implements Event {
-  const factory _TestStart({required final int time, required final Test test}) = _$_TestStart;
+  const factory _TestStart({
+    required final int time,
+    required final Test test,
+  }) = _$TestStartImpl;
 
-  factory _TestStart.fromJson(Map<String, dynamic> json) = _$_TestStart.fromJson;
+  factory _TestStart.fromJson(Map<String, dynamic> json) =
+      _$TestStartImpl.fromJson;
 
-  @override
   /// The time (in milliseconds) that has elapsed since the test runner started.
+  @override
   int get time;
 
   /// Metadata about the Test that started.
   Test get test;
+
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
-  _$$_TestStartCopyWith<_$_TestStart> get copyWith => throw _privateConstructorUsedError;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$TestStartImplCopyWith<_$TestStartImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$_PrintCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$_PrintCopyWith(_$_Print value, $Res Function(_$_Print) then) = __$$_PrintCopyWithImpl<$Res>;
+abstract class _$$PrintImplCopyWith<$Res> implements $EventCopyWith<$Res> {
+  factory _$$PrintImplCopyWith(
+    _$PrintImpl value,
+    $Res Function(_$PrintImpl) then,
+  ) = __$$PrintImplCopyWithImpl<$Res>;
   @override
-  $Res call({int time, @JsonKey(name: 'testID') int testId, String messageType, String message});
+  @useResult
+  $Res call({
+    int time,
+    @JsonKey(name: 'testID') int testId,
+    String messageType,
+    String message,
+  });
 }
 
 /// @nodoc
-class __$$_PrintCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> implements _$$_PrintCopyWith<$Res> {
-  __$$_PrintCopyWithImpl(_$_Print _value, $Res Function(_$_Print) _then) : super(_value, (v) => _then(v as _$_Print));
+class __$$PrintImplCopyWithImpl<$Res>
+    extends _$EventCopyWithImpl<$Res, _$PrintImpl>
+    implements _$$PrintImplCopyWith<$Res> {
+  __$$PrintImplCopyWithImpl(
+    _$PrintImpl _value,
+    $Res Function(_$PrintImpl) _then,
+  ) : super(_value, _then);
 
-  @override
-  _$_Print get _value => super._value as _$_Print;
-
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? time = freezed,
-    Object? testId = freezed,
-    Object? messageType = freezed,
-    Object? message = freezed,
+    Object? time = null,
+    Object? testId = null,
+    Object? messageType = null,
+    Object? message = null,
   }) {
     return _then(
-      _$_Print(
+      _$PrintImpl(
         time:
-            time == freezed
+            null == time
                 ? _value.time
                 : time // ignore: cast_nullable_to_non_nullable
                     as int,
         testId:
-            testId == freezed
+            null == testId
                 ? _value.testId
                 : testId // ignore: cast_nullable_to_non_nullable
                     as int,
         messageType:
-            messageType == freezed
+            null == messageType
                 ? _value.messageType
                 : messageType // ignore: cast_nullable_to_non_nullable
                     as String,
         message:
-            message == freezed
+            null == message
                 ? _value.message
                 : message // ignore: cast_nullable_to_non_nullable
                     as String,
@@ -1975,8 +2458,8 @@ class __$$_PrintCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> implements 
 
 /// @nodoc
 @JsonSerializable()
-class _$_Print implements _Print {
-  const _$_Print({
+class _$PrintImpl implements _Print {
+  const _$PrintImpl({
     required this.time,
     @JsonKey(name: 'testID') required this.testId,
     required this.messageType,
@@ -1984,7 +2467,8 @@ class _$_Print implements _Print {
     final String? $type,
   }) : $type = $type ?? 'print';
 
-  factory _$_Print.fromJson(Map<String, dynamic> json) => _$$_PrintFromJson(json);
+  factory _$PrintImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PrintImplFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -2012,34 +2496,40 @@ class _$_Print implements _Print {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Print &&
-            const DeepCollectionEquality().equals(other.time, time) &&
-            const DeepCollectionEquality().equals(other.testId, testId) &&
-            const DeepCollectionEquality().equals(other.messageType, messageType) &&
-            const DeepCollectionEquality().equals(other.message, message));
+            other is _$PrintImpl &&
+            (identical(other.time, time) || other.time == time) &&
+            (identical(other.testId, testId) || other.testId == testId) &&
+            (identical(other.messageType, messageType) ||
+                other.messageType == messageType) &&
+            (identical(other.message, message) || other.message == message));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(
-    runtimeType,
-    const DeepCollectionEquality().hash(time),
-    const DeepCollectionEquality().hash(testId),
-    const DeepCollectionEquality().hash(messageType),
-    const DeepCollectionEquality().hash(message),
-  );
+  int get hashCode =>
+      Object.hash(runtimeType, time, testId, messageType, message);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  _$$_PrintCopyWith<_$_Print> get copyWith => __$$_PrintCopyWithImpl<_$_Print>(this, _$identity);
+  @pragma('vm:prefer-inline')
+  _$$PrintImplCopyWith<_$PrintImpl> get copyWith =>
+      __$$PrintImplCopyWithImpl<_$PrintImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
+    required TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )
+    start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -2051,7 +2541,13 @@ class _$_Print implements _Print {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )
+    print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -2077,15 +2573,32 @@ class _$_Print implements _Print {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
-    TResult Function(int time, int count)? allSuites,
-    TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult? Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
+    TResult? Function(int time, int count)? allSuites,
+    TResult? Function(int time, Suite suite)? suite,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
-    TResult Function(int time, Group group)? group,
-    TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
-    TResult Function(
+    TResult? Function(int time, Group group)? group,
+    TResult? Function(int time, Test test)? testStart,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
+    TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
       String error,
@@ -2093,7 +2606,7 @@ class _$_Print implements _Print {
       bool isFailure,
     )?
     error,
-    TResult Function(
+    TResult? Function(
       int time,
       @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
       @JsonKey(name: 'testID') int testId,
@@ -2101,8 +2614,8 @@ class _$_Print implements _Print {
       bool skipped,
     )?
     testDone,
-    TResult Function(int time, bool? success)? done,
-    TResult Function(int time)? unknown,
+    TResult? Function(int time, bool? success)? done,
+    TResult? Function(int time)? unknown,
   }) {
     return print?.call(time, testId, messageType, message);
   }
@@ -2110,14 +2623,31 @@ class _$_Print implements _Print {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -2165,17 +2695,17 @@ class _$_Print implements _Print {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult Function(_Start value)? start,
-    TResult Function(_AllSuites value)? allSuites,
-    TResult Function(_Suite value)? suite,
-    TResult Function(_Debug value)? debug,
-    TResult Function(_Group value)? group,
-    TResult Function(_TestStart value)? testStart,
-    TResult Function(_Print value)? print,
-    TResult Function(_Error value)? error,
-    TResult Function(_TestDone value)? testDone,
-    TResult Function(_Done value)? done,
-    TResult Function(_Unknown value)? unknown,
+    TResult? Function(_Start value)? start,
+    TResult? Function(_AllSuites value)? allSuites,
+    TResult? Function(_Suite value)? suite,
+    TResult? Function(_Debug value)? debug,
+    TResult? Function(_Group value)? group,
+    TResult? Function(_TestStart value)? testStart,
+    TResult? Function(_Print value)? print,
+    TResult? Function(_Error value)? error,
+    TResult? Function(_TestDone value)? testDone,
+    TResult? Function(_Done value)? done,
+    TResult? Function(_Unknown value)? unknown,
   }) {
     return print?.call(this);
   }
@@ -2204,7 +2734,7 @@ class _$_Print implements _Print {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PrintToJson(this);
+    return _$$PrintImplToJson(this);
   }
 }
 
@@ -2214,12 +2744,12 @@ abstract class _Print implements Event {
     @JsonKey(name: 'testID') required final int testId,
     required final String messageType,
     required final String message,
-  }) = _$_Print;
+  }) = _$PrintImpl;
 
-  factory _Print.fromJson(Map<String, dynamic> json) = _$_Print.fromJson;
+  factory _Print.fromJson(Map<String, dynamic> json) = _$PrintImpl.fromJson;
 
-  @override
   /// The time (in milliseconds) that has elapsed since the test runner started.
+  @override
   int get time;
 
   /// The ID of the test that printed a message.
@@ -2231,15 +2761,23 @@ abstract class _Print implements Event {
 
   /// The message that was printed.
   String get message;
+
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
-  _$$_PrintCopyWith<_$_Print> get copyWith => throw _privateConstructorUsedError;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$PrintImplCopyWith<_$PrintImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$_ErrorCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$_ErrorCopyWith(_$_Error value, $Res Function(_$_Error) then) = __$$_ErrorCopyWithImpl<$Res>;
+abstract class _$$ErrorImplCopyWith<$Res> implements $EventCopyWith<$Res> {
+  factory _$$ErrorImplCopyWith(
+    _$ErrorImpl value,
+    $Res Function(_$ErrorImpl) then,
+  ) = __$$ErrorImplCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call({
     int time,
     @JsonKey(name: 'testID') int testId,
@@ -2250,44 +2788,49 @@ abstract class _$$_ErrorCopyWith<$Res> implements $EventCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_ErrorCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> implements _$$_ErrorCopyWith<$Res> {
-  __$$_ErrorCopyWithImpl(_$_Error _value, $Res Function(_$_Error) _then) : super(_value, (v) => _then(v as _$_Error));
+class __$$ErrorImplCopyWithImpl<$Res>
+    extends _$EventCopyWithImpl<$Res, _$ErrorImpl>
+    implements _$$ErrorImplCopyWith<$Res> {
+  __$$ErrorImplCopyWithImpl(
+    _$ErrorImpl _value,
+    $Res Function(_$ErrorImpl) _then,
+  ) : super(_value, _then);
 
-  @override
-  _$_Error get _value => super._value as _$_Error;
-
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? time = freezed,
-    Object? testId = freezed,
-    Object? error = freezed,
-    Object? stacktrace = freezed,
-    Object? isFailure = freezed,
+    Object? time = null,
+    Object? testId = null,
+    Object? error = null,
+    Object? stacktrace = null,
+    Object? isFailure = null,
   }) {
     return _then(
-      _$_Error(
+      _$ErrorImpl(
         time:
-            time == freezed
+            null == time
                 ? _value.time
                 : time // ignore: cast_nullable_to_non_nullable
                     as int,
         testId:
-            testId == freezed
+            null == testId
                 ? _value.testId
                 : testId // ignore: cast_nullable_to_non_nullable
                     as int,
         error:
-            error == freezed
+            null == error
                 ? _value.error
                 : error // ignore: cast_nullable_to_non_nullable
                     as String,
         stacktrace:
-            stacktrace == freezed
+            null == stacktrace
                 ? _value.stacktrace
                 : stacktrace // ignore: cast_nullable_to_non_nullable
                     as String,
         isFailure:
-            isFailure == freezed
+            null == isFailure
                 ? _value.isFailure
                 : isFailure // ignore: cast_nullable_to_non_nullable
                     as bool,
@@ -2298,8 +2841,8 @@ class __$$_ErrorCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> implements 
 
 /// @nodoc
 @JsonSerializable()
-class _$_Error implements _Error {
-  const _$_Error({
+class _$ErrorImpl implements _Error {
+  const _$ErrorImpl({
     required this.time,
     @JsonKey(name: 'testID') required this.testId,
     required this.error,
@@ -2308,7 +2851,8 @@ class _$_Error implements _Error {
     final String? $type,
   }) : $type = $type ?? 'error';
 
-  factory _$_Error.fromJson(Map<String, dynamic> json) => _$$_ErrorFromJson(json);
+  factory _$ErrorImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ErrorImplFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -2341,36 +2885,42 @@ class _$_Error implements _Error {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Error &&
-            const DeepCollectionEquality().equals(other.time, time) &&
-            const DeepCollectionEquality().equals(other.testId, testId) &&
-            const DeepCollectionEquality().equals(other.error, error) &&
-            const DeepCollectionEquality().equals(other.stacktrace, stacktrace) &&
-            const DeepCollectionEquality().equals(other.isFailure, isFailure));
+            other is _$ErrorImpl &&
+            (identical(other.time, time) || other.time == time) &&
+            (identical(other.testId, testId) || other.testId == testId) &&
+            (identical(other.error, error) || other.error == error) &&
+            (identical(other.stacktrace, stacktrace) ||
+                other.stacktrace == stacktrace) &&
+            (identical(other.isFailure, isFailure) ||
+                other.isFailure == isFailure));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(
-    runtimeType,
-    const DeepCollectionEquality().hash(time),
-    const DeepCollectionEquality().hash(testId),
-    const DeepCollectionEquality().hash(error),
-    const DeepCollectionEquality().hash(stacktrace),
-    const DeepCollectionEquality().hash(isFailure),
-  );
+  int get hashCode =>
+      Object.hash(runtimeType, time, testId, error, stacktrace, isFailure);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  _$$_ErrorCopyWith<_$_Error> get copyWith => __$$_ErrorCopyWithImpl<_$_Error>(this, _$identity);
+  @pragma('vm:prefer-inline')
+  _$$ErrorImplCopyWith<_$ErrorImpl> get copyWith =>
+      __$$ErrorImplCopyWithImpl<_$ErrorImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
+    required TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )
+    start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -2382,7 +2932,13 @@ class _$_Error implements _Error {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )
+    print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -2408,15 +2964,32 @@ class _$_Error implements _Error {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
-    TResult Function(int time, int count)? allSuites,
-    TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult? Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
+    TResult? Function(int time, int count)? allSuites,
+    TResult? Function(int time, Suite suite)? suite,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
-    TResult Function(int time, Group group)? group,
-    TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
-    TResult Function(
+    TResult? Function(int time, Group group)? group,
+    TResult? Function(int time, Test test)? testStart,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
+    TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
       String error,
@@ -2424,7 +2997,7 @@ class _$_Error implements _Error {
       bool isFailure,
     )?
     error,
-    TResult Function(
+    TResult? Function(
       int time,
       @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
       @JsonKey(name: 'testID') int testId,
@@ -2432,8 +3005,8 @@ class _$_Error implements _Error {
       bool skipped,
     )?
     testDone,
-    TResult Function(int time, bool? success)? done,
-    TResult Function(int time)? unknown,
+    TResult? Function(int time, bool? success)? done,
+    TResult? Function(int time)? unknown,
   }) {
     return error?.call(time, testId, this.error, stacktrace, isFailure);
   }
@@ -2441,14 +3014,31 @@ class _$_Error implements _Error {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -2496,17 +3086,17 @@ class _$_Error implements _Error {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult Function(_Start value)? start,
-    TResult Function(_AllSuites value)? allSuites,
-    TResult Function(_Suite value)? suite,
-    TResult Function(_Debug value)? debug,
-    TResult Function(_Group value)? group,
-    TResult Function(_TestStart value)? testStart,
-    TResult Function(_Print value)? print,
-    TResult Function(_Error value)? error,
-    TResult Function(_TestDone value)? testDone,
-    TResult Function(_Done value)? done,
-    TResult Function(_Unknown value)? unknown,
+    TResult? Function(_Start value)? start,
+    TResult? Function(_AllSuites value)? allSuites,
+    TResult? Function(_Suite value)? suite,
+    TResult? Function(_Debug value)? debug,
+    TResult? Function(_Group value)? group,
+    TResult? Function(_TestStart value)? testStart,
+    TResult? Function(_Print value)? print,
+    TResult? Function(_Error value)? error,
+    TResult? Function(_TestDone value)? testDone,
+    TResult? Function(_Done value)? done,
+    TResult? Function(_Unknown value)? unknown,
   }) {
     return error?.call(this);
   }
@@ -2535,7 +3125,7 @@ class _$_Error implements _Error {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ErrorToJson(this);
+    return _$$ErrorImplToJson(this);
   }
 }
 
@@ -2546,12 +3136,12 @@ abstract class _Error implements Event {
     required final String error,
     @JsonKey(name: 'stackTrace') required final String stacktrace,
     required final bool isFailure,
-  }) = _$_Error;
+  }) = _$ErrorImpl;
 
-  factory _Error.fromJson(Map<String, dynamic> json) = _$_Error.fromJson;
+  factory _Error.fromJson(Map<String, dynamic> json) = _$ErrorImpl.fromJson;
 
-  @override
   /// The time (in milliseconds) that has elapsed since the test runner started.
+  @override
   int get time;
 
   /// The ID of the test that experienced the error.
@@ -2567,15 +3157,23 @@ abstract class _Error implements Event {
 
   /// Whether the error was a `TestFailure`.
   bool get isFailure;
+
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
-  _$$_ErrorCopyWith<_$_Error> get copyWith => throw _privateConstructorUsedError;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ErrorImplCopyWith<_$ErrorImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$_TestDoneCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$_TestDoneCopyWith(_$_TestDone value, $Res Function(_$_TestDone) then) = __$$_TestDoneCopyWithImpl<$Res>;
+abstract class _$$TestDoneImplCopyWith<$Res> implements $EventCopyWith<$Res> {
+  factory _$$TestDoneImplCopyWith(
+    _$TestDoneImpl value,
+    $Res Function(_$TestDoneImpl) then,
+  ) = __$$TestDoneImplCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call({
     int time,
     @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
@@ -2586,45 +3184,49 @@ abstract class _$$_TestDoneCopyWith<$Res> implements $EventCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_TestDoneCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> implements _$$_TestDoneCopyWith<$Res> {
-  __$$_TestDoneCopyWithImpl(_$_TestDone _value, $Res Function(_$_TestDone) _then)
-    : super(_value, (v) => _then(v as _$_TestDone));
+class __$$TestDoneImplCopyWithImpl<$Res>
+    extends _$EventCopyWithImpl<$Res, _$TestDoneImpl>
+    implements _$$TestDoneImplCopyWith<$Res> {
+  __$$TestDoneImplCopyWithImpl(
+    _$TestDoneImpl _value,
+    $Res Function(_$TestDoneImpl) _then,
+  ) : super(_value, _then);
 
-  @override
-  _$_TestDone get _value => super._value as _$_TestDone;
-
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? time = freezed,
-    Object? result = freezed,
-    Object? testId = freezed,
-    Object? hidden = freezed,
-    Object? skipped = freezed,
+    Object? time = null,
+    Object? result = null,
+    Object? testId = null,
+    Object? hidden = null,
+    Object? skipped = null,
   }) {
     return _then(
-      _$_TestDone(
+      _$TestDoneImpl(
         time:
-            time == freezed
+            null == time
                 ? _value.time
                 : time // ignore: cast_nullable_to_non_nullable
                     as int,
         result:
-            result == freezed
+            null == result
                 ? _value.result
                 : result // ignore: cast_nullable_to_non_nullable
                     as TestResult,
         testId:
-            testId == freezed
+            null == testId
                 ? _value.testId
                 : testId // ignore: cast_nullable_to_non_nullable
                     as int,
         hidden:
-            hidden == freezed
+            null == hidden
                 ? _value.hidden
                 : hidden // ignore: cast_nullable_to_non_nullable
                     as bool,
         skipped:
-            skipped == freezed
+            null == skipped
                 ? _value.skipped
                 : skipped // ignore: cast_nullable_to_non_nullable
                     as bool,
@@ -2635,8 +3237,8 @@ class __$$_TestDoneCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> implemen
 
 /// @nodoc
 @JsonSerializable()
-class _$_TestDone implements _TestDone {
-  const _$_TestDone({
+class _$TestDoneImpl implements _TestDone {
+  const _$TestDoneImpl({
     required this.time,
     @JsonKey(unknownEnumValue: TestResult.unknown) required this.result,
     @JsonKey(name: 'testID') required this.testId,
@@ -2645,7 +3247,8 @@ class _$_TestDone implements _TestDone {
     final String? $type,
   }) : $type = $type ?? 'testDone';
 
-  factory _$_TestDone.fromJson(Map<String, dynamic> json) => _$$_TestDoneFromJson(json);
+  factory _$TestDoneImpl.fromJson(Map<String, dynamic> json) =>
+      _$$TestDoneImplFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -2678,36 +3281,40 @@ class _$_TestDone implements _TestDone {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_TestDone &&
-            const DeepCollectionEquality().equals(other.time, time) &&
-            const DeepCollectionEquality().equals(other.result, result) &&
-            const DeepCollectionEquality().equals(other.testId, testId) &&
-            const DeepCollectionEquality().equals(other.hidden, hidden) &&
-            const DeepCollectionEquality().equals(other.skipped, skipped));
+            other is _$TestDoneImpl &&
+            (identical(other.time, time) || other.time == time) &&
+            (identical(other.result, result) || other.result == result) &&
+            (identical(other.testId, testId) || other.testId == testId) &&
+            (identical(other.hidden, hidden) || other.hidden == hidden) &&
+            (identical(other.skipped, skipped) || other.skipped == skipped));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(
-    runtimeType,
-    const DeepCollectionEquality().hash(time),
-    const DeepCollectionEquality().hash(result),
-    const DeepCollectionEquality().hash(testId),
-    const DeepCollectionEquality().hash(hidden),
-    const DeepCollectionEquality().hash(skipped),
-  );
+  int get hashCode =>
+      Object.hash(runtimeType, time, result, testId, hidden, skipped);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  _$$_TestDoneCopyWith<_$_TestDone> get copyWith => __$$_TestDoneCopyWithImpl<_$_TestDone>(this, _$identity);
+  @pragma('vm:prefer-inline')
+  _$$TestDoneImplCopyWith<_$TestDoneImpl> get copyWith =>
+      __$$TestDoneImplCopyWithImpl<_$TestDoneImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
+    required TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )
+    start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -2719,7 +3326,13 @@ class _$_TestDone implements _TestDone {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )
+    print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -2745,15 +3358,32 @@ class _$_TestDone implements _TestDone {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
-    TResult Function(int time, int count)? allSuites,
-    TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult? Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
+    TResult? Function(int time, int count)? allSuites,
+    TResult? Function(int time, Suite suite)? suite,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
-    TResult Function(int time, Group group)? group,
-    TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
-    TResult Function(
+    TResult? Function(int time, Group group)? group,
+    TResult? Function(int time, Test test)? testStart,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
+    TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
       String error,
@@ -2761,7 +3391,7 @@ class _$_TestDone implements _TestDone {
       bool isFailure,
     )?
     error,
-    TResult Function(
+    TResult? Function(
       int time,
       @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
       @JsonKey(name: 'testID') int testId,
@@ -2769,8 +3399,8 @@ class _$_TestDone implements _TestDone {
       bool skipped,
     )?
     testDone,
-    TResult Function(int time, bool? success)? done,
-    TResult Function(int time)? unknown,
+    TResult? Function(int time, bool? success)? done,
+    TResult? Function(int time)? unknown,
   }) {
     return testDone?.call(time, result, testId, hidden, skipped);
   }
@@ -2778,14 +3408,31 @@ class _$_TestDone implements _TestDone {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -2833,17 +3480,17 @@ class _$_TestDone implements _TestDone {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult Function(_Start value)? start,
-    TResult Function(_AllSuites value)? allSuites,
-    TResult Function(_Suite value)? suite,
-    TResult Function(_Debug value)? debug,
-    TResult Function(_Group value)? group,
-    TResult Function(_TestStart value)? testStart,
-    TResult Function(_Print value)? print,
-    TResult Function(_Error value)? error,
-    TResult Function(_TestDone value)? testDone,
-    TResult Function(_Done value)? done,
-    TResult Function(_Unknown value)? unknown,
+    TResult? Function(_Start value)? start,
+    TResult? Function(_AllSuites value)? allSuites,
+    TResult? Function(_Suite value)? suite,
+    TResult? Function(_Debug value)? debug,
+    TResult? Function(_Group value)? group,
+    TResult? Function(_TestStart value)? testStart,
+    TResult? Function(_Print value)? print,
+    TResult? Function(_Error value)? error,
+    TResult? Function(_TestDone value)? testDone,
+    TResult? Function(_Done value)? done,
+    TResult? Function(_Unknown value)? unknown,
   }) {
     return testDone?.call(this);
   }
@@ -2872,23 +3519,25 @@ class _$_TestDone implements _TestDone {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_TestDoneToJson(this);
+    return _$$TestDoneImplToJson(this);
   }
 }
 
 abstract class _TestDone implements Event {
   const factory _TestDone({
     required final int time,
-    @JsonKey(unknownEnumValue: TestResult.unknown) required final TestResult result,
+    @JsonKey(unknownEnumValue: TestResult.unknown)
+    required final TestResult result,
     @JsonKey(name: 'testID') required final int testId,
     required final bool hidden,
     required final bool skipped,
-  }) = _$_TestDone;
+  }) = _$TestDoneImpl;
 
-  factory _TestDone.fromJson(Map<String, dynamic> json) = _$_TestDone.fromJson;
+  factory _TestDone.fromJson(Map<String, dynamic> json) =
+      _$TestDoneImpl.fromJson;
 
-  @override
   /// The time (in milliseconds) that has elapsed since the test runner started.
+  @override
   int get time;
 
   /// The result of the test.
@@ -2904,36 +3553,47 @@ abstract class _TestDone implements Event {
 
   /// Whether the test (or some part of it) was skipped.
   bool get skipped;
+
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
-  _$$_TestDoneCopyWith<_$_TestDone> get copyWith => throw _privateConstructorUsedError;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$TestDoneImplCopyWith<_$TestDoneImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$_DoneCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$_DoneCopyWith(_$_Done value, $Res Function(_$_Done) then) = __$$_DoneCopyWithImpl<$Res>;
+abstract class _$$DoneImplCopyWith<$Res> implements $EventCopyWith<$Res> {
+  factory _$$DoneImplCopyWith(
+    _$DoneImpl value,
+    $Res Function(_$DoneImpl) then,
+  ) = __$$DoneImplCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call({int time, bool? success});
 }
 
 /// @nodoc
-class __$$_DoneCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> implements _$$_DoneCopyWith<$Res> {
-  __$$_DoneCopyWithImpl(_$_Done _value, $Res Function(_$_Done) _then) : super(_value, (v) => _then(v as _$_Done));
+class __$$DoneImplCopyWithImpl<$Res>
+    extends _$EventCopyWithImpl<$Res, _$DoneImpl>
+    implements _$$DoneImplCopyWith<$Res> {
+  __$$DoneImplCopyWithImpl(_$DoneImpl _value, $Res Function(_$DoneImpl) _then)
+    : super(_value, _then);
 
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
   @override
-  _$_Done get _value => super._value as _$_Done;
-
-  @override
-  $Res call({Object? time = freezed, Object? success = freezed}) {
+  $Res call({Object? time = null, Object? success = freezed}) {
     return _then(
-      _$_Done(
+      _$DoneImpl(
         time:
-            time == freezed
+            null == time
                 ? _value.time
                 : time // ignore: cast_nullable_to_non_nullable
                     as int,
         success:
-            success == freezed
+            freezed == success
                 ? _value.success
                 : success // ignore: cast_nullable_to_non_nullable
                     as bool?,
@@ -2944,10 +3604,12 @@ class __$$_DoneCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> implements _
 
 /// @nodoc
 @JsonSerializable()
-class _$_Done implements _Done {
-  const _$_Done({required this.time, this.success, final String? $type}) : $type = $type ?? 'done';
+class _$DoneImpl implements _Done {
+  const _$DoneImpl({required this.time, this.success, final String? $type})
+    : $type = $type ?? 'done';
 
-  factory _$_Done.fromJson(Map<String, dynamic> json) => _$$_DoneFromJson(json);
+  factory _$DoneImpl.fromJson(Map<String, dynamic> json) =>
+      _$$DoneImplFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -2969,27 +3631,36 @@ class _$_Done implements _Done {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Done &&
-            const DeepCollectionEquality().equals(other.time, time) &&
-            const DeepCollectionEquality().equals(other.success, success));
+            other is _$DoneImpl &&
+            (identical(other.time, time) || other.time == time) &&
+            (identical(other.success, success) || other.success == success));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(time), const DeepCollectionEquality().hash(success));
+  int get hashCode => Object.hash(runtimeType, time, success);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  _$$_DoneCopyWith<_$_Done> get copyWith => __$$_DoneCopyWithImpl<_$_Done>(this, _$identity);
+  @pragma('vm:prefer-inline')
+  _$$DoneImplCopyWith<_$DoneImpl> get copyWith =>
+      __$$DoneImplCopyWithImpl<_$DoneImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
+    required TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )
+    start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -3001,7 +3672,13 @@ class _$_Done implements _Done {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )
+    print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -3027,15 +3704,32 @@ class _$_Done implements _Done {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
-    TResult Function(int time, int count)? allSuites,
-    TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult? Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
+    TResult? Function(int time, int count)? allSuites,
+    TResult? Function(int time, Suite suite)? suite,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
-    TResult Function(int time, Group group)? group,
-    TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
-    TResult Function(
+    TResult? Function(int time, Group group)? group,
+    TResult? Function(int time, Test test)? testStart,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
+    TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
       String error,
@@ -3043,7 +3737,7 @@ class _$_Done implements _Done {
       bool isFailure,
     )?
     error,
-    TResult Function(
+    TResult? Function(
       int time,
       @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
       @JsonKey(name: 'testID') int testId,
@@ -3051,8 +3745,8 @@ class _$_Done implements _Done {
       bool skipped,
     )?
     testDone,
-    TResult Function(int time, bool? success)? done,
-    TResult Function(int time)? unknown,
+    TResult? Function(int time, bool? success)? done,
+    TResult? Function(int time)? unknown,
   }) {
     return done?.call(time, success);
   }
@@ -3060,14 +3754,31 @@ class _$_Done implements _Done {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -3115,17 +3826,17 @@ class _$_Done implements _Done {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult Function(_Start value)? start,
-    TResult Function(_AllSuites value)? allSuites,
-    TResult Function(_Suite value)? suite,
-    TResult Function(_Debug value)? debug,
-    TResult Function(_Group value)? group,
-    TResult Function(_TestStart value)? testStart,
-    TResult Function(_Print value)? print,
-    TResult Function(_Error value)? error,
-    TResult Function(_TestDone value)? testDone,
-    TResult Function(_Done value)? done,
-    TResult Function(_Unknown value)? unknown,
+    TResult? Function(_Start value)? start,
+    TResult? Function(_AllSuites value)? allSuites,
+    TResult? Function(_Suite value)? suite,
+    TResult? Function(_Debug value)? debug,
+    TResult? Function(_Group value)? group,
+    TResult? Function(_TestStart value)? testStart,
+    TResult? Function(_Print value)? print,
+    TResult? Function(_Error value)? error,
+    TResult? Function(_TestDone value)? testDone,
+    TResult? Function(_Done value)? done,
+    TResult? Function(_Unknown value)? unknown,
   }) {
     return done?.call(this);
   }
@@ -3154,17 +3865,18 @@ class _$_Done implements _Done {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_DoneToJson(this);
+    return _$$DoneImplToJson(this);
   }
 }
 
 abstract class _Done implements Event {
-  const factory _Done({required final int time, final bool? success}) = _$_Done;
+  const factory _Done({required final int time, final bool? success}) =
+      _$DoneImpl;
 
-  factory _Done.fromJson(Map<String, dynamic> json) = _$_Done.fromJson;
+  factory _Done.fromJson(Map<String, dynamic> json) = _$DoneImpl.fromJson;
 
-  @override
   /// The time (in milliseconds) that has elapsed since the test runner started.
+  @override
   int get time;
 
   /// Whether all tests succeeded (or were skipped).
@@ -3172,32 +3884,44 @@ abstract class _Done implements Event {
   /// Will be `null` if the test runner was close before all tests completed
   /// running.
   bool? get success;
+
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
-  _$$_DoneCopyWith<_$_Done> get copyWith => throw _privateConstructorUsedError;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$DoneImplCopyWith<_$DoneImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$_UnknownCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$$_UnknownCopyWith(_$_Unknown value, $Res Function(_$_Unknown) then) = __$$_UnknownCopyWithImpl<$Res>;
+abstract class _$$UnknownImplCopyWith<$Res> implements $EventCopyWith<$Res> {
+  factory _$$UnknownImplCopyWith(
+    _$UnknownImpl value,
+    $Res Function(_$UnknownImpl) then,
+  ) = __$$UnknownImplCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call({int time});
 }
 
 /// @nodoc
-class __$$_UnknownCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> implements _$$_UnknownCopyWith<$Res> {
-  __$$_UnknownCopyWithImpl(_$_Unknown _value, $Res Function(_$_Unknown) _then)
-    : super(_value, (v) => _then(v as _$_Unknown));
+class __$$UnknownImplCopyWithImpl<$Res>
+    extends _$EventCopyWithImpl<$Res, _$UnknownImpl>
+    implements _$$UnknownImplCopyWith<$Res> {
+  __$$UnknownImplCopyWithImpl(
+    _$UnknownImpl _value,
+    $Res Function(_$UnknownImpl) _then,
+  ) : super(_value, _then);
 
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
   @override
-  _$_Unknown get _value => super._value as _$_Unknown;
-
-  @override
-  $Res call({Object? time = freezed}) {
+  $Res call({Object? time = null}) {
     return _then(
-      _$_Unknown(
+      _$UnknownImpl(
         time:
-            time == freezed
+            null == time
                 ? _value.time
                 : time // ignore: cast_nullable_to_non_nullable
                     as int,
@@ -3208,10 +3932,12 @@ class __$$_UnknownCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res> implement
 
 /// @nodoc
 @JsonSerializable()
-class _$_Unknown implements _Unknown {
-  const _$_Unknown({required this.time, final String? $type}) : $type = $type ?? 'unknown';
+class _$UnknownImpl implements _Unknown {
+  const _$UnknownImpl({required this.time, final String? $type})
+    : $type = $type ?? 'unknown';
 
-  factory _$_Unknown.fromJson(Map<String, dynamic> json) => _$$_UnknownFromJson(json);
+  factory _$UnknownImpl.fromJson(Map<String, dynamic> json) =>
+      _$$UnknownImplFromJson(json);
 
   /// The time (in milliseconds) that has elapsed since the test runner started.
   @override
@@ -3226,25 +3952,35 @@ class _$_Unknown implements _Unknown {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Unknown &&
-            const DeepCollectionEquality().equals(other.time, time));
+            other is _$UnknownImpl &&
+            (identical(other.time, time) || other.time == time));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(time));
+  int get hashCode => Object.hash(runtimeType, time);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  _$$_UnknownCopyWith<_$_Unknown> get copyWith => __$$_UnknownCopyWithImpl<_$_Unknown>(this, _$identity);
+  @pragma('vm:prefer-inline')
+  _$$UnknownImplCopyWith<_$UnknownImpl> get copyWith =>
+      __$$UnknownImplCopyWithImpl<_$UnknownImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(int time, String protocolVersion, String? runnerVersion, int pid) start,
+    required TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )
+    start,
     required TResult Function(int time, int count) allSuites,
     required TResult Function(int time, Suite suite) suite,
     required TResult Function(
@@ -3256,7 +3992,13 @@ class _$_Unknown implements _Unknown {
     debug,
     required TResult Function(int time, Group group) group,
     required TResult Function(int time, Test test) testStart,
-    required TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message) print,
+    required TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )
+    print,
     required TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -3282,15 +4024,32 @@ class _$_Unknown implements _Unknown {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
-    TResult Function(int time, int count)? allSuites,
-    TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult? Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
+    TResult? Function(int time, int count)? allSuites,
+    TResult? Function(int time, Suite suite)? suite,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
-    TResult Function(int time, Group group)? group,
-    TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
-    TResult Function(
+    TResult? Function(int time, Group group)? group,
+    TResult? Function(int time, Test test)? testStart,
+    TResult? Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
+    TResult? Function(
       int time,
       @JsonKey(name: 'testID') int testId,
       String error,
@@ -3298,7 +4057,7 @@ class _$_Unknown implements _Unknown {
       bool isFailure,
     )?
     error,
-    TResult Function(
+    TResult? Function(
       int time,
       @JsonKey(unknownEnumValue: TestResult.unknown) TestResult result,
       @JsonKey(name: 'testID') int testId,
@@ -3306,8 +4065,8 @@ class _$_Unknown implements _Unknown {
       bool skipped,
     )?
     testDone,
-    TResult Function(int time, bool? success)? done,
-    TResult Function(int time)? unknown,
+    TResult? Function(int time, bool? success)? done,
+    TResult? Function(int time)? unknown,
   }) {
     return unknown?.call(time);
   }
@@ -3315,14 +4074,31 @@ class _$_Unknown implements _Unknown {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(int time, String protocolVersion, String? runnerVersion, int pid)? start,
+    TResult Function(
+      int time,
+      String protocolVersion,
+      String? runnerVersion,
+      int pid,
+    )?
+    start,
     TResult Function(int time, int count)? allSuites,
     TResult Function(int time, Suite suite)? suite,
-    TResult Function(int time, @JsonKey(name: 'suiteID') int suiteId, String? observatory, String? remoteDebugger)?
+    TResult Function(
+      int time,
+      @JsonKey(name: 'suiteID') int suiteId,
+      String? observatory,
+      String? remoteDebugger,
+    )?
     debug,
     TResult Function(int time, Group group)? group,
     TResult Function(int time, Test test)? testStart,
-    TResult Function(int time, @JsonKey(name: 'testID') int testId, String messageType, String message)? print,
+    TResult Function(
+      int time,
+      @JsonKey(name: 'testID') int testId,
+      String messageType,
+      String message,
+    )?
+    print,
     TResult Function(
       int time,
       @JsonKey(name: 'testID') int testId,
@@ -3370,17 +4146,17 @@ class _$_Unknown implements _Unknown {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult Function(_Start value)? start,
-    TResult Function(_AllSuites value)? allSuites,
-    TResult Function(_Suite value)? suite,
-    TResult Function(_Debug value)? debug,
-    TResult Function(_Group value)? group,
-    TResult Function(_TestStart value)? testStart,
-    TResult Function(_Print value)? print,
-    TResult Function(_Error value)? error,
-    TResult Function(_TestDone value)? testDone,
-    TResult Function(_Done value)? done,
-    TResult Function(_Unknown value)? unknown,
+    TResult? Function(_Start value)? start,
+    TResult? Function(_AllSuites value)? allSuites,
+    TResult? Function(_Suite value)? suite,
+    TResult? Function(_Debug value)? debug,
+    TResult? Function(_Group value)? group,
+    TResult? Function(_TestStart value)? testStart,
+    TResult? Function(_Print value)? print,
+    TResult? Function(_Error value)? error,
+    TResult? Function(_TestDone value)? testDone,
+    TResult? Function(_Done value)? done,
+    TResult? Function(_Unknown value)? unknown,
   }) {
     return unknown?.call(this);
   }
@@ -3409,19 +4185,23 @@ class _$_Unknown implements _Unknown {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_UnknownToJson(this);
+    return _$$UnknownImplToJson(this);
   }
 }
 
 abstract class _Unknown implements Event {
-  const factory _Unknown({required final int time}) = _$_Unknown;
+  const factory _Unknown({required final int time}) = _$UnknownImpl;
 
-  factory _Unknown.fromJson(Map<String, dynamic> json) = _$_Unknown.fromJson;
+  factory _Unknown.fromJson(Map<String, dynamic> json) = _$UnknownImpl.fromJson;
 
-  @override
   /// The time (in milliseconds) that has elapsed since the test runner started.
-  int get time;
   @override
-  @JsonKey(ignore: true)
-  _$$_UnknownCopyWith<_$_Unknown> get copyWith => throw _privateConstructorUsedError;
+  int get time;
+
+  /// Create a copy of Event
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$UnknownImplCopyWith<_$UnknownImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }

--- a/lib/src/parser/json_reporter_protocol_0_1/event.g.dart
+++ b/lib/src/parser/json_reporter_protocol_0_1/event.g.dart
@@ -8,24 +8,26 @@ part of 'event.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$StartImpl _$$StartImplFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$StartImpl', json, ($checkedConvert) {
-  final val = _$StartImpl(
-    time: $checkedConvert('time', (v) => (v as num).toInt()),
-    protocolVersion: $checkedConvert('protocolVersion', (v) => v as String),
-    runnerVersion: $checkedConvert('runnerVersion', (v) => v as String?),
-    pid: $checkedConvert('pid', (v) => (v as num).toInt()),
-    $type: $checkedConvert('type', (v) => v as String?),
-  );
-  return val;
-}, fieldKeyMap: const {r'$type': 'type'});
+_$StartImpl _$$StartImplFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(r'_$StartImpl', json, ($checkedConvert) {
+      final val = _$StartImpl(
+        time: $checkedConvert('time', (v) => (v as num).toInt()),
+        protocolVersion: $checkedConvert('protocolVersion', (v) => v as String),
+        runnerVersion: $checkedConvert('runnerVersion', (v) => v as String?),
+        pid: $checkedConvert('pid', (v) => (v as num).toInt()),
+        $type: $checkedConvert('type', (v) => v as String?),
+      );
+      return val;
+    }, fieldKeyMap: const {r'$type': 'type'});
 
-Map<String, dynamic> _$$StartImplToJson(_$StartImpl instance) => <String, dynamic>{
-  'time': instance.time,
-  'protocolVersion': instance.protocolVersion,
-  'runnerVersion': instance.runnerVersion,
-  'pid': instance.pid,
-  'type': instance.$type,
-};
+Map<String, dynamic> _$$StartImplToJson(_$StartImpl instance) =>
+    <String, dynamic>{
+      'time': instance.time,
+      'protocolVersion': instance.protocolVersion,
+      'runnerVersion': instance.runnerVersion,
+      'pid': instance.pid,
+      'type': instance.$type,
+    };
 
 _$AllSuitesImpl _$$AllSuitesImplFromJson(Map<String, dynamic> json) =>
     $checkedCreate(r'_$AllSuitesImpl', json, ($checkedConvert) {
@@ -37,122 +39,158 @@ _$AllSuitesImpl _$$AllSuitesImplFromJson(Map<String, dynamic> json) =>
       return val;
     }, fieldKeyMap: const {r'$type': 'type'});
 
-Map<String, dynamic> _$$AllSuitesImplToJson(_$AllSuitesImpl instance) => <String, dynamic>{
-  'time': instance.time,
-  'count': instance.count,
-  'type': instance.$type,
-};
+Map<String, dynamic> _$$AllSuitesImplToJson(_$AllSuitesImpl instance) =>
+    <String, dynamic>{
+      'time': instance.time,
+      'count': instance.count,
+      'type': instance.$type,
+    };
 
-_$SuiteImpl _$$SuiteImplFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$SuiteImpl', json, ($checkedConvert) {
-  final val = _$SuiteImpl(
-    time: $checkedConvert('time', (v) => (v as num).toInt()),
-    suite: $checkedConvert('suite', (v) => Suite.fromJson(v as Map<String, dynamic>)),
-    $type: $checkedConvert('type', (v) => v as String?),
-  );
-  return val;
-}, fieldKeyMap: const {r'$type': 'type'});
-
-Map<String, dynamic> _$$SuiteImplToJson(_$SuiteImpl instance) => <String, dynamic>{
-  'time': instance.time,
-  'suite': instance.suite.toJson(),
-  'type': instance.$type,
-};
-
-_$DebugImpl _$$DebugImplFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$DebugImpl', json, ($checkedConvert) {
-  final val = _$DebugImpl(
-    time: $checkedConvert('time', (v) => (v as num).toInt()),
-    suiteId: $checkedConvert('suiteID', (v) => (v as num).toInt()),
-    observatory: $checkedConvert('observatory', (v) => v as String?),
-    remoteDebugger: $checkedConvert('remoteDebugger', (v) => v as String?),
-    $type: $checkedConvert('type', (v) => v as String?),
-  );
-  return val;
-}, fieldKeyMap: const {'suiteId': 'suiteID', r'$type': 'type'});
-
-Map<String, dynamic> _$$DebugImplToJson(_$DebugImpl instance) => <String, dynamic>{
-  'time': instance.time,
-  'suiteID': instance.suiteId,
-  'observatory': instance.observatory,
-  'remoteDebugger': instance.remoteDebugger,
-  'type': instance.$type,
-};
-
-_$GroupImpl _$$GroupImplFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$GroupImpl', json, ($checkedConvert) {
-  final val = _$GroupImpl(
-    time: $checkedConvert('time', (v) => (v as num).toInt()),
-    group: $checkedConvert('group', (v) => Group.fromJson(v as Map<String, dynamic>)),
-    $type: $checkedConvert('type', (v) => v as String?),
-  );
-  return val;
-}, fieldKeyMap: const {r'$type': 'type'});
-
-Map<String, dynamic> _$$GroupImplToJson(_$GroupImpl instance) => <String, dynamic>{
-  'time': instance.time,
-  'group': instance.group.toJson(),
-  'type': instance.$type,
-};
-
-_$TestStartImpl _$$TestStartImplFromJson(Map<String, dynamic> json) =>
-    $checkedCreate(r'_$TestStartImpl', json, ($checkedConvert) {
-      final val = _$TestStartImpl(
+_$SuiteImpl _$$SuiteImplFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(r'_$SuiteImpl', json, ($checkedConvert) {
+      final val = _$SuiteImpl(
         time: $checkedConvert('time', (v) => (v as num).toInt()),
-        test: $checkedConvert('test', (v) => Test.fromJson(v as Map<String, dynamic>)),
+        suite: $checkedConvert(
+          'suite',
+          (v) => Suite.fromJson(v as Map<String, dynamic>),
+        ),
         $type: $checkedConvert('type', (v) => v as String?),
       );
       return val;
     }, fieldKeyMap: const {r'$type': 'type'});
 
-Map<String, dynamic> _$$TestStartImplToJson(_$TestStartImpl instance) => <String, dynamic>{
-  'time': instance.time,
-  'test': instance.test.toJson(),
-  'type': instance.$type,
-};
+Map<String, dynamic> _$$SuiteImplToJson(_$SuiteImpl instance) =>
+    <String, dynamic>{
+      'time': instance.time,
+      'suite': instance.suite.toJson(),
+      'type': instance.$type,
+    };
 
-_$PrintImpl _$$PrintImplFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$PrintImpl', json, ($checkedConvert) {
-  final val = _$PrintImpl(
-    time: $checkedConvert('time', (v) => (v as num).toInt()),
-    testId: $checkedConvert('testID', (v) => (v as num).toInt()),
-    messageType: $checkedConvert('messageType', (v) => v as String),
-    message: $checkedConvert('message', (v) => v as String),
-    $type: $checkedConvert('type', (v) => v as String?),
-  );
-  return val;
-}, fieldKeyMap: const {'testId': 'testID', r'$type': 'type'});
+_$DebugImpl _$$DebugImplFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(r'_$DebugImpl', json, ($checkedConvert) {
+      final val = _$DebugImpl(
+        time: $checkedConvert('time', (v) => (v as num).toInt()),
+        suiteId: $checkedConvert('suiteID', (v) => (v as num).toInt()),
+        observatory: $checkedConvert('observatory', (v) => v as String?),
+        remoteDebugger: $checkedConvert('remoteDebugger', (v) => v as String?),
+        $type: $checkedConvert('type', (v) => v as String?),
+      );
+      return val;
+    }, fieldKeyMap: const {'suiteId': 'suiteID', r'$type': 'type'});
 
-Map<String, dynamic> _$$PrintImplToJson(_$PrintImpl instance) => <String, dynamic>{
-  'time': instance.time,
-  'testID': instance.testId,
-  'messageType': instance.messageType,
-  'message': instance.message,
-  'type': instance.$type,
-};
+Map<String, dynamic> _$$DebugImplToJson(_$DebugImpl instance) =>
+    <String, dynamic>{
+      'time': instance.time,
+      'suiteID': instance.suiteId,
+      'observatory': instance.observatory,
+      'remoteDebugger': instance.remoteDebugger,
+      'type': instance.$type,
+    };
 
-_$ErrorImpl _$$ErrorImplFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$ErrorImpl', json, ($checkedConvert) {
-  final val = _$ErrorImpl(
-    time: $checkedConvert('time', (v) => (v as num).toInt()),
-    testId: $checkedConvert('testID', (v) => (v as num).toInt()),
-    error: $checkedConvert('error', (v) => v as String),
-    stacktrace: $checkedConvert('stackTrace', (v) => v as String),
-    isFailure: $checkedConvert('isFailure', (v) => v as bool),
-    $type: $checkedConvert('type', (v) => v as String?),
-  );
-  return val;
-}, fieldKeyMap: const {'testId': 'testID', 'stacktrace': 'stackTrace', r'$type': 'type'});
+_$GroupImpl _$$GroupImplFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(r'_$GroupImpl', json, ($checkedConvert) {
+      final val = _$GroupImpl(
+        time: $checkedConvert('time', (v) => (v as num).toInt()),
+        group: $checkedConvert(
+          'group',
+          (v) => Group.fromJson(v as Map<String, dynamic>),
+        ),
+        $type: $checkedConvert('type', (v) => v as String?),
+      );
+      return val;
+    }, fieldKeyMap: const {r'$type': 'type'});
 
-Map<String, dynamic> _$$ErrorImplToJson(_$ErrorImpl instance) => <String, dynamic>{
-  'time': instance.time,
-  'testID': instance.testId,
-  'error': instance.error,
-  'stackTrace': instance.stacktrace,
-  'isFailure': instance.isFailure,
-  'type': instance.$type,
-};
+Map<String, dynamic> _$$GroupImplToJson(_$GroupImpl instance) =>
+    <String, dynamic>{
+      'time': instance.time,
+      'group': instance.group.toJson(),
+      'type': instance.$type,
+    };
+
+_$TestStartImpl _$$TestStartImplFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(r'_$TestStartImpl', json, ($checkedConvert) {
+      final val = _$TestStartImpl(
+        time: $checkedConvert('time', (v) => (v as num).toInt()),
+        test: $checkedConvert(
+          'test',
+          (v) => Test.fromJson(v as Map<String, dynamic>),
+        ),
+        $type: $checkedConvert('type', (v) => v as String?),
+      );
+      return val;
+    }, fieldKeyMap: const {r'$type': 'type'});
+
+Map<String, dynamic> _$$TestStartImplToJson(_$TestStartImpl instance) =>
+    <String, dynamic>{
+      'time': instance.time,
+      'test': instance.test.toJson(),
+      'type': instance.$type,
+    };
+
+_$PrintImpl _$$PrintImplFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(r'_$PrintImpl', json, ($checkedConvert) {
+      final val = _$PrintImpl(
+        time: $checkedConvert('time', (v) => (v as num).toInt()),
+        testId: $checkedConvert('testID', (v) => (v as num).toInt()),
+        messageType: $checkedConvert('messageType', (v) => v as String),
+        message: $checkedConvert('message', (v) => v as String),
+        $type: $checkedConvert('type', (v) => v as String?),
+      );
+      return val;
+    }, fieldKeyMap: const {'testId': 'testID', r'$type': 'type'});
+
+Map<String, dynamic> _$$PrintImplToJson(_$PrintImpl instance) =>
+    <String, dynamic>{
+      'time': instance.time,
+      'testID': instance.testId,
+      'messageType': instance.messageType,
+      'message': instance.message,
+      'type': instance.$type,
+    };
+
+_$ErrorImpl _$$ErrorImplFromJson(Map<String, dynamic> json) => $checkedCreate(
+  r'_$ErrorImpl',
+  json,
+  ($checkedConvert) {
+    final val = _$ErrorImpl(
+      time: $checkedConvert('time', (v) => (v as num).toInt()),
+      testId: $checkedConvert('testID', (v) => (v as num).toInt()),
+      error: $checkedConvert('error', (v) => v as String),
+      stacktrace: $checkedConvert('stackTrace', (v) => v as String),
+      isFailure: $checkedConvert('isFailure', (v) => v as bool),
+      $type: $checkedConvert('type', (v) => v as String?),
+    );
+    return val;
+  },
+  fieldKeyMap: const {
+    'testId': 'testID',
+    'stacktrace': 'stackTrace',
+    r'$type': 'type',
+  },
+);
+
+Map<String, dynamic> _$$ErrorImplToJson(_$ErrorImpl instance) =>
+    <String, dynamic>{
+      'time': instance.time,
+      'testID': instance.testId,
+      'error': instance.error,
+      'stackTrace': instance.stacktrace,
+      'isFailure': instance.isFailure,
+      'type': instance.$type,
+    };
 
 _$TestDoneImpl _$$TestDoneImplFromJson(Map<String, dynamic> json) =>
     $checkedCreate(r'_$TestDoneImpl', json, ($checkedConvert) {
       final val = _$TestDoneImpl(
         time: $checkedConvert('time', (v) => (v as num).toInt()),
-        result: $checkedConvert('result', (v) => $enumDecode(_$TestResultEnumMap, v, unknownValue: TestResult.unknown)),
+        result: $checkedConvert(
+          'result',
+          (v) => $enumDecode(
+            _$TestResultEnumMap,
+            v,
+            unknownValue: TestResult.unknown,
+          ),
+        ),
         testId: $checkedConvert('testID', (v) => (v as num).toInt()),
         hidden: $checkedConvert('hidden', (v) => v as bool),
         skipped: $checkedConvert('skipped', (v) => v as bool),
@@ -161,14 +199,15 @@ _$TestDoneImpl _$$TestDoneImplFromJson(Map<String, dynamic> json) =>
       return val;
     }, fieldKeyMap: const {'testId': 'testID', r'$type': 'type'});
 
-Map<String, dynamic> _$$TestDoneImplToJson(_$TestDoneImpl instance) => <String, dynamic>{
-  'time': instance.time,
-  'result': _$TestResultEnumMap[instance.result]!,
-  'testID': instance.testId,
-  'hidden': instance.hidden,
-  'skipped': instance.skipped,
-  'type': instance.$type,
-};
+Map<String, dynamic> _$$TestDoneImplToJson(_$TestDoneImpl instance) =>
+    <String, dynamic>{
+      'time': instance.time,
+      'result': _$TestResultEnumMap[instance.result]!,
+      'testID': instance.testId,
+      'hidden': instance.hidden,
+      'skipped': instance.skipped,
+      'type': instance.$type,
+    };
 
 const _$TestResultEnumMap = {
   TestResult.success: 'success',
@@ -177,20 +216,22 @@ const _$TestResultEnumMap = {
   TestResult.unknown: 'unknown',
 };
 
-_$DoneImpl _$$DoneImplFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$DoneImpl', json, ($checkedConvert) {
-  final val = _$DoneImpl(
-    time: $checkedConvert('time', (v) => (v as num).toInt()),
-    success: $checkedConvert('success', (v) => v as bool?),
-    $type: $checkedConvert('type', (v) => v as String?),
-  );
-  return val;
-}, fieldKeyMap: const {r'$type': 'type'});
+_$DoneImpl _$$DoneImplFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(r'_$DoneImpl', json, ($checkedConvert) {
+      final val = _$DoneImpl(
+        time: $checkedConvert('time', (v) => (v as num).toInt()),
+        success: $checkedConvert('success', (v) => v as bool?),
+        $type: $checkedConvert('type', (v) => v as String?),
+      );
+      return val;
+    }, fieldKeyMap: const {r'$type': 'type'});
 
-Map<String, dynamic> _$$DoneImplToJson(_$DoneImpl instance) => <String, dynamic>{
-  'time': instance.time,
-  'success': instance.success,
-  'type': instance.$type,
-};
+Map<String, dynamic> _$$DoneImplToJson(_$DoneImpl instance) =>
+    <String, dynamic>{
+      'time': instance.time,
+      'success': instance.success,
+      'type': instance.$type,
+    };
 
 _$UnknownImpl _$$UnknownImplFromJson(Map<String, dynamic> json) =>
     $checkedCreate(r'_$UnknownImpl', json, ($checkedConvert) {
@@ -201,7 +242,5 @@ _$UnknownImpl _$$UnknownImplFromJson(Map<String, dynamic> json) =>
       return val;
     }, fieldKeyMap: const {r'$type': 'type'});
 
-Map<String, dynamic> _$$UnknownImplToJson(_$UnknownImpl instance) => <String, dynamic>{
-  'time': instance.time,
-  'type': instance.$type,
-};
+Map<String, dynamic> _$$UnknownImplToJson(_$UnknownImpl instance) =>
+    <String, dynamic>{'time': instance.time, 'type': instance.$type};

--- a/lib/src/parser/json_reporter_protocol_0_1/event.g.dart
+++ b/lib/src/parser/json_reporter_protocol_0_1/event.g.dart
@@ -8,166 +8,206 @@ part of 'event.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_Start _$$_StartFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$_Start', json, ($checkedConvert) {
-  final val = _$_Start(
-    time: $checkedConvert('time', (v) => v as int),
-    protocolVersion: $checkedConvert('protocolVersion', (v) => v as String),
-    runnerVersion: $checkedConvert('runnerVersion', (v) => v as String?),
-    pid: $checkedConvert('pid', (v) => v as int),
-    $type: $checkedConvert('type', (v) => v as String?),
-  );
-  return val;
-}, fieldKeyMap: const {r'$type': 'type'});
-
-Map<String, dynamic> _$$_StartToJson(_$_Start instance) => <String, dynamic>{
-  'time': instance.time,
-  'protocolVersion': instance.protocolVersion,
-  'runnerVersion': instance.runnerVersion,
-  'pid': instance.pid,
-  'type': instance.$type,
-};
-
-_$_AllSuites _$$_AllSuitesFromJson(Map<String, dynamic> json) =>
-    $checkedCreate(r'_$_AllSuites', json, ($checkedConvert) {
-      final val = _$_AllSuites(
-        time: $checkedConvert('time', (v) => v as int),
-        count: $checkedConvert('count', (v) => v as int),
+_$StartImpl _$$StartImplFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(r'_$StartImpl', json, ($checkedConvert) {
+      final val = _$StartImpl(
+        time: $checkedConvert('time', (v) => (v as num).toInt()),
+        protocolVersion: $checkedConvert('protocolVersion', (v) => v as String),
+        runnerVersion: $checkedConvert('runnerVersion', (v) => v as String?),
+        pid: $checkedConvert('pid', (v) => (v as num).toInt()),
         $type: $checkedConvert('type', (v) => v as String?),
       );
       return val;
     }, fieldKeyMap: const {r'$type': 'type'});
 
-Map<String, dynamic> _$$_AllSuitesToJson(_$_AllSuites instance) => <String, dynamic>{
-  'time': instance.time,
-  'count': instance.count,
-  'type': instance.$type,
-};
+Map<String, dynamic> _$$StartImplToJson(_$StartImpl instance) =>
+    <String, dynamic>{
+      'time': instance.time,
+      'protocolVersion': instance.protocolVersion,
+      'runnerVersion': instance.runnerVersion,
+      'pid': instance.pid,
+      'type': instance.$type,
+    };
 
-_$_Suite _$$_SuiteFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$_Suite', json, ($checkedConvert) {
-  final val = _$_Suite(
-    time: $checkedConvert('time', (v) => v as int),
-    suite: $checkedConvert('suite', (v) => Suite.fromJson(v as Map<String, dynamic>)),
-    $type: $checkedConvert('type', (v) => v as String?),
-  );
-  return val;
-}, fieldKeyMap: const {r'$type': 'type'});
-
-Map<String, dynamic> _$$_SuiteToJson(_$_Suite instance) => <String, dynamic>{
-  'time': instance.time,
-  'suite': instance.suite.toJson(),
-  'type': instance.$type,
-};
-
-_$_Debug _$$_DebugFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$_Debug', json, ($checkedConvert) {
-  final val = _$_Debug(
-    time: $checkedConvert('time', (v) => v as int),
-    suiteId: $checkedConvert('suiteID', (v) => v as int),
-    observatory: $checkedConvert('observatory', (v) => v as String?),
-    remoteDebugger: $checkedConvert('remoteDebugger', (v) => v as String?),
-    $type: $checkedConvert('type', (v) => v as String?),
-  );
-  return val;
-}, fieldKeyMap: const {'suiteId': 'suiteID', r'$type': 'type'});
-
-Map<String, dynamic> _$$_DebugToJson(_$_Debug instance) => <String, dynamic>{
-  'time': instance.time,
-  'suiteID': instance.suiteId,
-  'observatory': instance.observatory,
-  'remoteDebugger': instance.remoteDebugger,
-  'type': instance.$type,
-};
-
-_$_Group _$$_GroupFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$_Group', json, ($checkedConvert) {
-  final val = _$_Group(
-    time: $checkedConvert('time', (v) => v as int),
-    group: $checkedConvert('group', (v) => Group.fromJson(v as Map<String, dynamic>)),
-    $type: $checkedConvert('type', (v) => v as String?),
-  );
-  return val;
-}, fieldKeyMap: const {r'$type': 'type'});
-
-Map<String, dynamic> _$$_GroupToJson(_$_Group instance) => <String, dynamic>{
-  'time': instance.time,
-  'group': instance.group.toJson(),
-  'type': instance.$type,
-};
-
-_$_TestStart _$$_TestStartFromJson(Map<String, dynamic> json) =>
-    $checkedCreate(r'_$_TestStart', json, ($checkedConvert) {
-      final val = _$_TestStart(
-        time: $checkedConvert('time', (v) => v as int),
-        test: $checkedConvert('test', (v) => Test.fromJson(v as Map<String, dynamic>)),
+_$AllSuitesImpl _$$AllSuitesImplFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(r'_$AllSuitesImpl', json, ($checkedConvert) {
+      final val = _$AllSuitesImpl(
+        time: $checkedConvert('time', (v) => (v as num).toInt()),
+        count: $checkedConvert('count', (v) => (v as num).toInt()),
         $type: $checkedConvert('type', (v) => v as String?),
       );
       return val;
     }, fieldKeyMap: const {r'$type': 'type'});
 
-Map<String, dynamic> _$$_TestStartToJson(_$_TestStart instance) => <String, dynamic>{
-  'time': instance.time,
-  'test': instance.test.toJson(),
-  'type': instance.$type,
-};
+Map<String, dynamic> _$$AllSuitesImplToJson(_$AllSuitesImpl instance) =>
+    <String, dynamic>{
+      'time': instance.time,
+      'count': instance.count,
+      'type': instance.$type,
+    };
 
-_$_Print _$$_PrintFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$_Print', json, ($checkedConvert) {
-  final val = _$_Print(
-    time: $checkedConvert('time', (v) => v as int),
-    testId: $checkedConvert('testID', (v) => v as int),
-    messageType: $checkedConvert('messageType', (v) => v as String),
-    message: $checkedConvert('message', (v) => v as String),
-    $type: $checkedConvert('type', (v) => v as String?),
-  );
-  return val;
-}, fieldKeyMap: const {'testId': 'testID', r'$type': 'type'});
+_$SuiteImpl _$$SuiteImplFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(r'_$SuiteImpl', json, ($checkedConvert) {
+      final val = _$SuiteImpl(
+        time: $checkedConvert('time', (v) => (v as num).toInt()),
+        suite: $checkedConvert(
+          'suite',
+          (v) => Suite.fromJson(v as Map<String, dynamic>),
+        ),
+        $type: $checkedConvert('type', (v) => v as String?),
+      );
+      return val;
+    }, fieldKeyMap: const {r'$type': 'type'});
 
-Map<String, dynamic> _$$_PrintToJson(_$_Print instance) => <String, dynamic>{
-  'time': instance.time,
-  'testID': instance.testId,
-  'messageType': instance.messageType,
-  'message': instance.message,
-  'type': instance.$type,
-};
+Map<String, dynamic> _$$SuiteImplToJson(_$SuiteImpl instance) =>
+    <String, dynamic>{
+      'time': instance.time,
+      'suite': instance.suite.toJson(),
+      'type': instance.$type,
+    };
 
-_$_Error _$$_ErrorFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$_Error', json, ($checkedConvert) {
-  final val = _$_Error(
-    time: $checkedConvert('time', (v) => v as int),
-    testId: $checkedConvert('testID', (v) => v as int),
-    error: $checkedConvert('error', (v) => v as String),
-    stacktrace: $checkedConvert('stackTrace', (v) => v as String),
-    isFailure: $checkedConvert('isFailure', (v) => v as bool),
-    $type: $checkedConvert('type', (v) => v as String?),
-  );
-  return val;
-}, fieldKeyMap: const {'testId': 'testID', 'stacktrace': 'stackTrace', r'$type': 'type'});
+_$DebugImpl _$$DebugImplFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(r'_$DebugImpl', json, ($checkedConvert) {
+      final val = _$DebugImpl(
+        time: $checkedConvert('time', (v) => (v as num).toInt()),
+        suiteId: $checkedConvert('suiteID', (v) => (v as num).toInt()),
+        observatory: $checkedConvert('observatory', (v) => v as String?),
+        remoteDebugger: $checkedConvert('remoteDebugger', (v) => v as String?),
+        $type: $checkedConvert('type', (v) => v as String?),
+      );
+      return val;
+    }, fieldKeyMap: const {'suiteId': 'suiteID', r'$type': 'type'});
 
-Map<String, dynamic> _$$_ErrorToJson(_$_Error instance) => <String, dynamic>{
-  'time': instance.time,
-  'testID': instance.testId,
-  'error': instance.error,
-  'stackTrace': instance.stacktrace,
-  'isFailure': instance.isFailure,
-  'type': instance.$type,
-};
+Map<String, dynamic> _$$DebugImplToJson(_$DebugImpl instance) =>
+    <String, dynamic>{
+      'time': instance.time,
+      'suiteID': instance.suiteId,
+      'observatory': instance.observatory,
+      'remoteDebugger': instance.remoteDebugger,
+      'type': instance.$type,
+    };
 
-_$_TestDone _$$_TestDoneFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$_TestDone', json, ($checkedConvert) {
-  final val = _$_TestDone(
-    time: $checkedConvert('time', (v) => v as int),
-    result: $checkedConvert('result', (v) => $enumDecode(_$TestResultEnumMap, v, unknownValue: TestResult.unknown)),
-    testId: $checkedConvert('testID', (v) => v as int),
-    hidden: $checkedConvert('hidden', (v) => v as bool),
-    skipped: $checkedConvert('skipped', (v) => v as bool),
-    $type: $checkedConvert('type', (v) => v as String?),
-  );
-  return val;
-}, fieldKeyMap: const {'testId': 'testID', r'$type': 'type'});
+_$GroupImpl _$$GroupImplFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(r'_$GroupImpl', json, ($checkedConvert) {
+      final val = _$GroupImpl(
+        time: $checkedConvert('time', (v) => (v as num).toInt()),
+        group: $checkedConvert(
+          'group',
+          (v) => Group.fromJson(v as Map<String, dynamic>),
+        ),
+        $type: $checkedConvert('type', (v) => v as String?),
+      );
+      return val;
+    }, fieldKeyMap: const {r'$type': 'type'});
 
-Map<String, dynamic> _$$_TestDoneToJson(_$_TestDone instance) => <String, dynamic>{
-  'time': instance.time,
-  'result': _$TestResultEnumMap[instance.result]!,
-  'testID': instance.testId,
-  'hidden': instance.hidden,
-  'skipped': instance.skipped,
-  'type': instance.$type,
-};
+Map<String, dynamic> _$$GroupImplToJson(_$GroupImpl instance) =>
+    <String, dynamic>{
+      'time': instance.time,
+      'group': instance.group.toJson(),
+      'type': instance.$type,
+    };
+
+_$TestStartImpl _$$TestStartImplFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(r'_$TestStartImpl', json, ($checkedConvert) {
+      final val = _$TestStartImpl(
+        time: $checkedConvert('time', (v) => (v as num).toInt()),
+        test: $checkedConvert(
+          'test',
+          (v) => Test.fromJson(v as Map<String, dynamic>),
+        ),
+        $type: $checkedConvert('type', (v) => v as String?),
+      );
+      return val;
+    }, fieldKeyMap: const {r'$type': 'type'});
+
+Map<String, dynamic> _$$TestStartImplToJson(_$TestStartImpl instance) =>
+    <String, dynamic>{
+      'time': instance.time,
+      'test': instance.test.toJson(),
+      'type': instance.$type,
+    };
+
+_$PrintImpl _$$PrintImplFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(r'_$PrintImpl', json, ($checkedConvert) {
+      final val = _$PrintImpl(
+        time: $checkedConvert('time', (v) => (v as num).toInt()),
+        testId: $checkedConvert('testID', (v) => (v as num).toInt()),
+        messageType: $checkedConvert('messageType', (v) => v as String),
+        message: $checkedConvert('message', (v) => v as String),
+        $type: $checkedConvert('type', (v) => v as String?),
+      );
+      return val;
+    }, fieldKeyMap: const {'testId': 'testID', r'$type': 'type'});
+
+Map<String, dynamic> _$$PrintImplToJson(_$PrintImpl instance) =>
+    <String, dynamic>{
+      'time': instance.time,
+      'testID': instance.testId,
+      'messageType': instance.messageType,
+      'message': instance.message,
+      'type': instance.$type,
+    };
+
+_$ErrorImpl _$$ErrorImplFromJson(Map<String, dynamic> json) => $checkedCreate(
+  r'_$ErrorImpl',
+  json,
+  ($checkedConvert) {
+    final val = _$ErrorImpl(
+      time: $checkedConvert('time', (v) => (v as num).toInt()),
+      testId: $checkedConvert('testID', (v) => (v as num).toInt()),
+      error: $checkedConvert('error', (v) => v as String),
+      stacktrace: $checkedConvert('stackTrace', (v) => v as String),
+      isFailure: $checkedConvert('isFailure', (v) => v as bool),
+      $type: $checkedConvert('type', (v) => v as String?),
+    );
+    return val;
+  },
+  fieldKeyMap: const {
+    'testId': 'testID',
+    'stacktrace': 'stackTrace',
+    r'$type': 'type',
+  },
+);
+
+Map<String, dynamic> _$$ErrorImplToJson(_$ErrorImpl instance) =>
+    <String, dynamic>{
+      'time': instance.time,
+      'testID': instance.testId,
+      'error': instance.error,
+      'stackTrace': instance.stacktrace,
+      'isFailure': instance.isFailure,
+      'type': instance.$type,
+    };
+
+_$TestDoneImpl _$$TestDoneImplFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(r'_$TestDoneImpl', json, ($checkedConvert) {
+      final val = _$TestDoneImpl(
+        time: $checkedConvert('time', (v) => (v as num).toInt()),
+        result: $checkedConvert(
+          'result',
+          (v) => $enumDecode(
+            _$TestResultEnumMap,
+            v,
+            unknownValue: TestResult.unknown,
+          ),
+        ),
+        testId: $checkedConvert('testID', (v) => (v as num).toInt()),
+        hidden: $checkedConvert('hidden', (v) => v as bool),
+        skipped: $checkedConvert('skipped', (v) => v as bool),
+        $type: $checkedConvert('type', (v) => v as String?),
+      );
+      return val;
+    }, fieldKeyMap: const {'testId': 'testID', r'$type': 'type'});
+
+Map<String, dynamic> _$$TestDoneImplToJson(_$TestDoneImpl instance) =>
+    <String, dynamic>{
+      'time': instance.time,
+      'result': _$TestResultEnumMap[instance.result]!,
+      'testID': instance.testId,
+      'hidden': instance.hidden,
+      'skipped': instance.skipped,
+      'type': instance.$type,
+    };
 
 const _$TestResultEnumMap = {
   TestResult.success: 'success',
@@ -176,30 +216,31 @@ const _$TestResultEnumMap = {
   TestResult.unknown: 'unknown',
 };
 
-_$_Done _$$_DoneFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$_Done', json, ($checkedConvert) {
-  final val = _$_Done(
-    time: $checkedConvert('time', (v) => v as int),
-    success: $checkedConvert('success', (v) => v as bool?),
-    $type: $checkedConvert('type', (v) => v as String?),
-  );
-  return val;
-}, fieldKeyMap: const {r'$type': 'type'});
+_$DoneImpl _$$DoneImplFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(r'_$DoneImpl', json, ($checkedConvert) {
+      final val = _$DoneImpl(
+        time: $checkedConvert('time', (v) => (v as num).toInt()),
+        success: $checkedConvert('success', (v) => v as bool?),
+        $type: $checkedConvert('type', (v) => v as String?),
+      );
+      return val;
+    }, fieldKeyMap: const {r'$type': 'type'});
 
-Map<String, dynamic> _$$_DoneToJson(_$_Done instance) => <String, dynamic>{
-  'time': instance.time,
-  'success': instance.success,
-  'type': instance.$type,
-};
+Map<String, dynamic> _$$DoneImplToJson(_$DoneImpl instance) =>
+    <String, dynamic>{
+      'time': instance.time,
+      'success': instance.success,
+      'type': instance.$type,
+    };
 
-_$_Unknown _$$_UnknownFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$_Unknown', json, ($checkedConvert) {
-  final val = _$_Unknown(
-    time: $checkedConvert('time', (v) => v as int),
-    $type: $checkedConvert('type', (v) => v as String?),
-  );
-  return val;
-}, fieldKeyMap: const {r'$type': 'type'});
+_$UnknownImpl _$$UnknownImplFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(r'_$UnknownImpl', json, ($checkedConvert) {
+      final val = _$UnknownImpl(
+        time: $checkedConvert('time', (v) => (v as num).toInt()),
+        $type: $checkedConvert('type', (v) => v as String?),
+      );
+      return val;
+    }, fieldKeyMap: const {r'$type': 'type'});
 
-Map<String, dynamic> _$$_UnknownToJson(_$_Unknown instance) => <String, dynamic>{
-  'time': instance.time,
-  'type': instance.$type,
-};
+Map<String, dynamic> _$$UnknownImplToJson(_$UnknownImpl instance) =>
+    <String, dynamic>{'time': instance.time, 'type': instance.$type};

--- a/lib/src/parser/json_reporter_protocol_0_1/event.g.dart
+++ b/lib/src/parser/json_reporter_protocol_0_1/event.g.dart
@@ -8,26 +8,24 @@ part of 'event.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$StartImpl _$$StartImplFromJson(Map<String, dynamic> json) =>
-    $checkedCreate(r'_$StartImpl', json, ($checkedConvert) {
-      final val = _$StartImpl(
-        time: $checkedConvert('time', (v) => (v as num).toInt()),
-        protocolVersion: $checkedConvert('protocolVersion', (v) => v as String),
-        runnerVersion: $checkedConvert('runnerVersion', (v) => v as String?),
-        pid: $checkedConvert('pid', (v) => (v as num).toInt()),
-        $type: $checkedConvert('type', (v) => v as String?),
-      );
-      return val;
-    }, fieldKeyMap: const {r'$type': 'type'});
+_$StartImpl _$$StartImplFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$StartImpl', json, ($checkedConvert) {
+  final val = _$StartImpl(
+    time: $checkedConvert('time', (v) => (v as num).toInt()),
+    protocolVersion: $checkedConvert('protocolVersion', (v) => v as String),
+    runnerVersion: $checkedConvert('runnerVersion', (v) => v as String?),
+    pid: $checkedConvert('pid', (v) => (v as num).toInt()),
+    $type: $checkedConvert('type', (v) => v as String?),
+  );
+  return val;
+}, fieldKeyMap: const {r'$type': 'type'});
 
-Map<String, dynamic> _$$StartImplToJson(_$StartImpl instance) =>
-    <String, dynamic>{
-      'time': instance.time,
-      'protocolVersion': instance.protocolVersion,
-      'runnerVersion': instance.runnerVersion,
-      'pid': instance.pid,
-      'type': instance.$type,
-    };
+Map<String, dynamic> _$$StartImplToJson(_$StartImpl instance) => <String, dynamic>{
+  'time': instance.time,
+  'protocolVersion': instance.protocolVersion,
+  'runnerVersion': instance.runnerVersion,
+  'pid': instance.pid,
+  'type': instance.$type,
+};
 
 _$AllSuitesImpl _$$AllSuitesImplFromJson(Map<String, dynamic> json) =>
     $checkedCreate(r'_$AllSuitesImpl', json, ($checkedConvert) {
@@ -39,158 +37,122 @@ _$AllSuitesImpl _$$AllSuitesImplFromJson(Map<String, dynamic> json) =>
       return val;
     }, fieldKeyMap: const {r'$type': 'type'});
 
-Map<String, dynamic> _$$AllSuitesImplToJson(_$AllSuitesImpl instance) =>
-    <String, dynamic>{
-      'time': instance.time,
-      'count': instance.count,
-      'type': instance.$type,
-    };
+Map<String, dynamic> _$$AllSuitesImplToJson(_$AllSuitesImpl instance) => <String, dynamic>{
+  'time': instance.time,
+  'count': instance.count,
+  'type': instance.$type,
+};
 
-_$SuiteImpl _$$SuiteImplFromJson(Map<String, dynamic> json) =>
-    $checkedCreate(r'_$SuiteImpl', json, ($checkedConvert) {
-      final val = _$SuiteImpl(
-        time: $checkedConvert('time', (v) => (v as num).toInt()),
-        suite: $checkedConvert(
-          'suite',
-          (v) => Suite.fromJson(v as Map<String, dynamic>),
-        ),
-        $type: $checkedConvert('type', (v) => v as String?),
-      );
-      return val;
-    }, fieldKeyMap: const {r'$type': 'type'});
+_$SuiteImpl _$$SuiteImplFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$SuiteImpl', json, ($checkedConvert) {
+  final val = _$SuiteImpl(
+    time: $checkedConvert('time', (v) => (v as num).toInt()),
+    suite: $checkedConvert('suite', (v) => Suite.fromJson(v as Map<String, dynamic>)),
+    $type: $checkedConvert('type', (v) => v as String?),
+  );
+  return val;
+}, fieldKeyMap: const {r'$type': 'type'});
 
-Map<String, dynamic> _$$SuiteImplToJson(_$SuiteImpl instance) =>
-    <String, dynamic>{
-      'time': instance.time,
-      'suite': instance.suite.toJson(),
-      'type': instance.$type,
-    };
+Map<String, dynamic> _$$SuiteImplToJson(_$SuiteImpl instance) => <String, dynamic>{
+  'time': instance.time,
+  'suite': instance.suite.toJson(),
+  'type': instance.$type,
+};
 
-_$DebugImpl _$$DebugImplFromJson(Map<String, dynamic> json) =>
-    $checkedCreate(r'_$DebugImpl', json, ($checkedConvert) {
-      final val = _$DebugImpl(
-        time: $checkedConvert('time', (v) => (v as num).toInt()),
-        suiteId: $checkedConvert('suiteID', (v) => (v as num).toInt()),
-        observatory: $checkedConvert('observatory', (v) => v as String?),
-        remoteDebugger: $checkedConvert('remoteDebugger', (v) => v as String?),
-        $type: $checkedConvert('type', (v) => v as String?),
-      );
-      return val;
-    }, fieldKeyMap: const {'suiteId': 'suiteID', r'$type': 'type'});
+_$DebugImpl _$$DebugImplFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$DebugImpl', json, ($checkedConvert) {
+  final val = _$DebugImpl(
+    time: $checkedConvert('time', (v) => (v as num).toInt()),
+    suiteId: $checkedConvert('suiteID', (v) => (v as num).toInt()),
+    observatory: $checkedConvert('observatory', (v) => v as String?),
+    remoteDebugger: $checkedConvert('remoteDebugger', (v) => v as String?),
+    $type: $checkedConvert('type', (v) => v as String?),
+  );
+  return val;
+}, fieldKeyMap: const {'suiteId': 'suiteID', r'$type': 'type'});
 
-Map<String, dynamic> _$$DebugImplToJson(_$DebugImpl instance) =>
-    <String, dynamic>{
-      'time': instance.time,
-      'suiteID': instance.suiteId,
-      'observatory': instance.observatory,
-      'remoteDebugger': instance.remoteDebugger,
-      'type': instance.$type,
-    };
+Map<String, dynamic> _$$DebugImplToJson(_$DebugImpl instance) => <String, dynamic>{
+  'time': instance.time,
+  'suiteID': instance.suiteId,
+  'observatory': instance.observatory,
+  'remoteDebugger': instance.remoteDebugger,
+  'type': instance.$type,
+};
 
-_$GroupImpl _$$GroupImplFromJson(Map<String, dynamic> json) =>
-    $checkedCreate(r'_$GroupImpl', json, ($checkedConvert) {
-      final val = _$GroupImpl(
-        time: $checkedConvert('time', (v) => (v as num).toInt()),
-        group: $checkedConvert(
-          'group',
-          (v) => Group.fromJson(v as Map<String, dynamic>),
-        ),
-        $type: $checkedConvert('type', (v) => v as String?),
-      );
-      return val;
-    }, fieldKeyMap: const {r'$type': 'type'});
+_$GroupImpl _$$GroupImplFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$GroupImpl', json, ($checkedConvert) {
+  final val = _$GroupImpl(
+    time: $checkedConvert('time', (v) => (v as num).toInt()),
+    group: $checkedConvert('group', (v) => Group.fromJson(v as Map<String, dynamic>)),
+    $type: $checkedConvert('type', (v) => v as String?),
+  );
+  return val;
+}, fieldKeyMap: const {r'$type': 'type'});
 
-Map<String, dynamic> _$$GroupImplToJson(_$GroupImpl instance) =>
-    <String, dynamic>{
-      'time': instance.time,
-      'group': instance.group.toJson(),
-      'type': instance.$type,
-    };
+Map<String, dynamic> _$$GroupImplToJson(_$GroupImpl instance) => <String, dynamic>{
+  'time': instance.time,
+  'group': instance.group.toJson(),
+  'type': instance.$type,
+};
 
 _$TestStartImpl _$$TestStartImplFromJson(Map<String, dynamic> json) =>
     $checkedCreate(r'_$TestStartImpl', json, ($checkedConvert) {
       final val = _$TestStartImpl(
         time: $checkedConvert('time', (v) => (v as num).toInt()),
-        test: $checkedConvert(
-          'test',
-          (v) => Test.fromJson(v as Map<String, dynamic>),
-        ),
+        test: $checkedConvert('test', (v) => Test.fromJson(v as Map<String, dynamic>)),
         $type: $checkedConvert('type', (v) => v as String?),
       );
       return val;
     }, fieldKeyMap: const {r'$type': 'type'});
 
-Map<String, dynamic> _$$TestStartImplToJson(_$TestStartImpl instance) =>
-    <String, dynamic>{
-      'time': instance.time,
-      'test': instance.test.toJson(),
-      'type': instance.$type,
-    };
+Map<String, dynamic> _$$TestStartImplToJson(_$TestStartImpl instance) => <String, dynamic>{
+  'time': instance.time,
+  'test': instance.test.toJson(),
+  'type': instance.$type,
+};
 
-_$PrintImpl _$$PrintImplFromJson(Map<String, dynamic> json) =>
-    $checkedCreate(r'_$PrintImpl', json, ($checkedConvert) {
-      final val = _$PrintImpl(
-        time: $checkedConvert('time', (v) => (v as num).toInt()),
-        testId: $checkedConvert('testID', (v) => (v as num).toInt()),
-        messageType: $checkedConvert('messageType', (v) => v as String),
-        message: $checkedConvert('message', (v) => v as String),
-        $type: $checkedConvert('type', (v) => v as String?),
-      );
-      return val;
-    }, fieldKeyMap: const {'testId': 'testID', r'$type': 'type'});
+_$PrintImpl _$$PrintImplFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$PrintImpl', json, ($checkedConvert) {
+  final val = _$PrintImpl(
+    time: $checkedConvert('time', (v) => (v as num).toInt()),
+    testId: $checkedConvert('testID', (v) => (v as num).toInt()),
+    messageType: $checkedConvert('messageType', (v) => v as String),
+    message: $checkedConvert('message', (v) => v as String),
+    $type: $checkedConvert('type', (v) => v as String?),
+  );
+  return val;
+}, fieldKeyMap: const {'testId': 'testID', r'$type': 'type'});
 
-Map<String, dynamic> _$$PrintImplToJson(_$PrintImpl instance) =>
-    <String, dynamic>{
-      'time': instance.time,
-      'testID': instance.testId,
-      'messageType': instance.messageType,
-      'message': instance.message,
-      'type': instance.$type,
-    };
+Map<String, dynamic> _$$PrintImplToJson(_$PrintImpl instance) => <String, dynamic>{
+  'time': instance.time,
+  'testID': instance.testId,
+  'messageType': instance.messageType,
+  'message': instance.message,
+  'type': instance.$type,
+};
 
-_$ErrorImpl _$$ErrorImplFromJson(Map<String, dynamic> json) => $checkedCreate(
-  r'_$ErrorImpl',
-  json,
-  ($checkedConvert) {
-    final val = _$ErrorImpl(
-      time: $checkedConvert('time', (v) => (v as num).toInt()),
-      testId: $checkedConvert('testID', (v) => (v as num).toInt()),
-      error: $checkedConvert('error', (v) => v as String),
-      stacktrace: $checkedConvert('stackTrace', (v) => v as String),
-      isFailure: $checkedConvert('isFailure', (v) => v as bool),
-      $type: $checkedConvert('type', (v) => v as String?),
-    );
-    return val;
-  },
-  fieldKeyMap: const {
-    'testId': 'testID',
-    'stacktrace': 'stackTrace',
-    r'$type': 'type',
-  },
-);
+_$ErrorImpl _$$ErrorImplFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$ErrorImpl', json, ($checkedConvert) {
+  final val = _$ErrorImpl(
+    time: $checkedConvert('time', (v) => (v as num).toInt()),
+    testId: $checkedConvert('testID', (v) => (v as num).toInt()),
+    error: $checkedConvert('error', (v) => v as String),
+    stacktrace: $checkedConvert('stackTrace', (v) => v as String),
+    isFailure: $checkedConvert('isFailure', (v) => v as bool),
+    $type: $checkedConvert('type', (v) => v as String?),
+  );
+  return val;
+}, fieldKeyMap: const {'testId': 'testID', 'stacktrace': 'stackTrace', r'$type': 'type'});
 
-Map<String, dynamic> _$$ErrorImplToJson(_$ErrorImpl instance) =>
-    <String, dynamic>{
-      'time': instance.time,
-      'testID': instance.testId,
-      'error': instance.error,
-      'stackTrace': instance.stacktrace,
-      'isFailure': instance.isFailure,
-      'type': instance.$type,
-    };
+Map<String, dynamic> _$$ErrorImplToJson(_$ErrorImpl instance) => <String, dynamic>{
+  'time': instance.time,
+  'testID': instance.testId,
+  'error': instance.error,
+  'stackTrace': instance.stacktrace,
+  'isFailure': instance.isFailure,
+  'type': instance.$type,
+};
 
 _$TestDoneImpl _$$TestDoneImplFromJson(Map<String, dynamic> json) =>
     $checkedCreate(r'_$TestDoneImpl', json, ($checkedConvert) {
       final val = _$TestDoneImpl(
         time: $checkedConvert('time', (v) => (v as num).toInt()),
-        result: $checkedConvert(
-          'result',
-          (v) => $enumDecode(
-            _$TestResultEnumMap,
-            v,
-            unknownValue: TestResult.unknown,
-          ),
-        ),
+        result: $checkedConvert('result', (v) => $enumDecode(_$TestResultEnumMap, v, unknownValue: TestResult.unknown)),
         testId: $checkedConvert('testID', (v) => (v as num).toInt()),
         hidden: $checkedConvert('hidden', (v) => v as bool),
         skipped: $checkedConvert('skipped', (v) => v as bool),
@@ -199,15 +161,14 @@ _$TestDoneImpl _$$TestDoneImplFromJson(Map<String, dynamic> json) =>
       return val;
     }, fieldKeyMap: const {'testId': 'testID', r'$type': 'type'});
 
-Map<String, dynamic> _$$TestDoneImplToJson(_$TestDoneImpl instance) =>
-    <String, dynamic>{
-      'time': instance.time,
-      'result': _$TestResultEnumMap[instance.result]!,
-      'testID': instance.testId,
-      'hidden': instance.hidden,
-      'skipped': instance.skipped,
-      'type': instance.$type,
-    };
+Map<String, dynamic> _$$TestDoneImplToJson(_$TestDoneImpl instance) => <String, dynamic>{
+  'time': instance.time,
+  'result': _$TestResultEnumMap[instance.result]!,
+  'testID': instance.testId,
+  'hidden': instance.hidden,
+  'skipped': instance.skipped,
+  'type': instance.$type,
+};
 
 const _$TestResultEnumMap = {
   TestResult.success: 'success',
@@ -216,22 +177,20 @@ const _$TestResultEnumMap = {
   TestResult.unknown: 'unknown',
 };
 
-_$DoneImpl _$$DoneImplFromJson(Map<String, dynamic> json) =>
-    $checkedCreate(r'_$DoneImpl', json, ($checkedConvert) {
-      final val = _$DoneImpl(
-        time: $checkedConvert('time', (v) => (v as num).toInt()),
-        success: $checkedConvert('success', (v) => v as bool?),
-        $type: $checkedConvert('type', (v) => v as String?),
-      );
-      return val;
-    }, fieldKeyMap: const {r'$type': 'type'});
+_$DoneImpl _$$DoneImplFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$DoneImpl', json, ($checkedConvert) {
+  final val = _$DoneImpl(
+    time: $checkedConvert('time', (v) => (v as num).toInt()),
+    success: $checkedConvert('success', (v) => v as bool?),
+    $type: $checkedConvert('type', (v) => v as String?),
+  );
+  return val;
+}, fieldKeyMap: const {r'$type': 'type'});
 
-Map<String, dynamic> _$$DoneImplToJson(_$DoneImpl instance) =>
-    <String, dynamic>{
-      'time': instance.time,
-      'success': instance.success,
-      'type': instance.$type,
-    };
+Map<String, dynamic> _$$DoneImplToJson(_$DoneImpl instance) => <String, dynamic>{
+  'time': instance.time,
+  'success': instance.success,
+  'type': instance.$type,
+};
 
 _$UnknownImpl _$$UnknownImplFromJson(Map<String, dynamic> json) =>
     $checkedCreate(r'_$UnknownImpl', json, ($checkedConvert) {
@@ -242,5 +201,7 @@ _$UnknownImpl _$$UnknownImplFromJson(Map<String, dynamic> json) =>
       return val;
     }, fieldKeyMap: const {r'$type': 'type'});
 
-Map<String, dynamic> _$$UnknownImplToJson(_$UnknownImpl instance) =>
-    <String, dynamic>{'time': instance.time, 'type': instance.$type};
+Map<String, dynamic> _$$UnknownImplToJson(_$UnknownImpl instance) => <String, dynamic>{
+  'time': instance.time,
+  'type': instance.$type,
+};

--- a/lib/src/parser/json_reporter_protocol_0_1/event.g.dart
+++ b/lib/src/parser/json_reporter_protocol_0_1/event.g.dart
@@ -8,224 +8,166 @@ part of 'event.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_Start _$$_StartFromJson(Map<String, dynamic> json) => $checkedCreate(
-      r'_$_Start',
-      json,
-      ($checkedConvert) {
-        final val = _$_Start(
-          time: $checkedConvert('time', (v) => v as int),
-          protocolVersion:
-              $checkedConvert('protocolVersion', (v) => v as String),
-          runnerVersion: $checkedConvert('runnerVersion', (v) => v as String?),
-          pid: $checkedConvert('pid', (v) => v as int),
-          $type: $checkedConvert('type', (v) => v as String?),
-        );
-        return val;
-      },
-      fieldKeyMap: const {r'$type': 'type'},
-    );
+_$_Start _$$_StartFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$_Start', json, ($checkedConvert) {
+  final val = _$_Start(
+    time: $checkedConvert('time', (v) => v as int),
+    protocolVersion: $checkedConvert('protocolVersion', (v) => v as String),
+    runnerVersion: $checkedConvert('runnerVersion', (v) => v as String?),
+    pid: $checkedConvert('pid', (v) => v as int),
+    $type: $checkedConvert('type', (v) => v as String?),
+  );
+  return val;
+}, fieldKeyMap: const {r'$type': 'type'});
 
 Map<String, dynamic> _$$_StartToJson(_$_Start instance) => <String, dynamic>{
-      'time': instance.time,
-      'protocolVersion': instance.protocolVersion,
-      'runnerVersion': instance.runnerVersion,
-      'pid': instance.pid,
-      'type': instance.$type,
-    };
+  'time': instance.time,
+  'protocolVersion': instance.protocolVersion,
+  'runnerVersion': instance.runnerVersion,
+  'pid': instance.pid,
+  'type': instance.$type,
+};
 
-_$_AllSuites _$$_AllSuitesFromJson(Map<String, dynamic> json) => $checkedCreate(
-      r'_$_AllSuites',
-      json,
-      ($checkedConvert) {
-        final val = _$_AllSuites(
-          time: $checkedConvert('time', (v) => v as int),
-          count: $checkedConvert('count', (v) => v as int),
-          $type: $checkedConvert('type', (v) => v as String?),
-        );
-        return val;
-      },
-      fieldKeyMap: const {r'$type': 'type'},
-    );
+_$_AllSuites _$$_AllSuitesFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(r'_$_AllSuites', json, ($checkedConvert) {
+      final val = _$_AllSuites(
+        time: $checkedConvert('time', (v) => v as int),
+        count: $checkedConvert('count', (v) => v as int),
+        $type: $checkedConvert('type', (v) => v as String?),
+      );
+      return val;
+    }, fieldKeyMap: const {r'$type': 'type'});
 
-Map<String, dynamic> _$$_AllSuitesToJson(_$_AllSuites instance) =>
-    <String, dynamic>{
-      'time': instance.time,
-      'count': instance.count,
-      'type': instance.$type,
-    };
+Map<String, dynamic> _$$_AllSuitesToJson(_$_AllSuites instance) => <String, dynamic>{
+  'time': instance.time,
+  'count': instance.count,
+  'type': instance.$type,
+};
 
-_$_Suite _$$_SuiteFromJson(Map<String, dynamic> json) => $checkedCreate(
-      r'_$_Suite',
-      json,
-      ($checkedConvert) {
-        final val = _$_Suite(
-          time: $checkedConvert('time', (v) => v as int),
-          suite: $checkedConvert(
-              'suite', (v) => Suite.fromJson(v as Map<String, dynamic>)),
-          $type: $checkedConvert('type', (v) => v as String?),
-        );
-        return val;
-      },
-      fieldKeyMap: const {r'$type': 'type'},
-    );
+_$_Suite _$$_SuiteFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$_Suite', json, ($checkedConvert) {
+  final val = _$_Suite(
+    time: $checkedConvert('time', (v) => v as int),
+    suite: $checkedConvert('suite', (v) => Suite.fromJson(v as Map<String, dynamic>)),
+    $type: $checkedConvert('type', (v) => v as String?),
+  );
+  return val;
+}, fieldKeyMap: const {r'$type': 'type'});
 
 Map<String, dynamic> _$$_SuiteToJson(_$_Suite instance) => <String, dynamic>{
-      'time': instance.time,
-      'suite': instance.suite.toJson(),
-      'type': instance.$type,
-    };
+  'time': instance.time,
+  'suite': instance.suite.toJson(),
+  'type': instance.$type,
+};
 
-_$_Debug _$$_DebugFromJson(Map<String, dynamic> json) => $checkedCreate(
-      r'_$_Debug',
-      json,
-      ($checkedConvert) {
-        final val = _$_Debug(
-          time: $checkedConvert('time', (v) => v as int),
-          suiteId: $checkedConvert('suiteID', (v) => v as int),
-          observatory: $checkedConvert('observatory', (v) => v as String?),
-          remoteDebugger:
-              $checkedConvert('remoteDebugger', (v) => v as String?),
-          $type: $checkedConvert('type', (v) => v as String?),
-        );
-        return val;
-      },
-      fieldKeyMap: const {'suiteId': 'suiteID', r'$type': 'type'},
-    );
+_$_Debug _$$_DebugFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$_Debug', json, ($checkedConvert) {
+  final val = _$_Debug(
+    time: $checkedConvert('time', (v) => v as int),
+    suiteId: $checkedConvert('suiteID', (v) => v as int),
+    observatory: $checkedConvert('observatory', (v) => v as String?),
+    remoteDebugger: $checkedConvert('remoteDebugger', (v) => v as String?),
+    $type: $checkedConvert('type', (v) => v as String?),
+  );
+  return val;
+}, fieldKeyMap: const {'suiteId': 'suiteID', r'$type': 'type'});
 
 Map<String, dynamic> _$$_DebugToJson(_$_Debug instance) => <String, dynamic>{
-      'time': instance.time,
-      'suiteID': instance.suiteId,
-      'observatory': instance.observatory,
-      'remoteDebugger': instance.remoteDebugger,
-      'type': instance.$type,
-    };
+  'time': instance.time,
+  'suiteID': instance.suiteId,
+  'observatory': instance.observatory,
+  'remoteDebugger': instance.remoteDebugger,
+  'type': instance.$type,
+};
 
-_$_Group _$$_GroupFromJson(Map<String, dynamic> json) => $checkedCreate(
-      r'_$_Group',
-      json,
-      ($checkedConvert) {
-        final val = _$_Group(
-          time: $checkedConvert('time', (v) => v as int),
-          group: $checkedConvert(
-              'group', (v) => Group.fromJson(v as Map<String, dynamic>)),
-          $type: $checkedConvert('type', (v) => v as String?),
-        );
-        return val;
-      },
-      fieldKeyMap: const {r'$type': 'type'},
-    );
+_$_Group _$$_GroupFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$_Group', json, ($checkedConvert) {
+  final val = _$_Group(
+    time: $checkedConvert('time', (v) => v as int),
+    group: $checkedConvert('group', (v) => Group.fromJson(v as Map<String, dynamic>)),
+    $type: $checkedConvert('type', (v) => v as String?),
+  );
+  return val;
+}, fieldKeyMap: const {r'$type': 'type'});
 
 Map<String, dynamic> _$$_GroupToJson(_$_Group instance) => <String, dynamic>{
-      'time': instance.time,
-      'group': instance.group.toJson(),
-      'type': instance.$type,
-    };
+  'time': instance.time,
+  'group': instance.group.toJson(),
+  'type': instance.$type,
+};
 
-_$_TestStart _$$_TestStartFromJson(Map<String, dynamic> json) => $checkedCreate(
-      r'_$_TestStart',
-      json,
-      ($checkedConvert) {
-        final val = _$_TestStart(
-          time: $checkedConvert('time', (v) => v as int),
-          test: $checkedConvert(
-              'test', (v) => Test.fromJson(v as Map<String, dynamic>)),
-          $type: $checkedConvert('type', (v) => v as String?),
-        );
-        return val;
-      },
-      fieldKeyMap: const {r'$type': 'type'},
-    );
+_$_TestStart _$$_TestStartFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(r'_$_TestStart', json, ($checkedConvert) {
+      final val = _$_TestStart(
+        time: $checkedConvert('time', (v) => v as int),
+        test: $checkedConvert('test', (v) => Test.fromJson(v as Map<String, dynamic>)),
+        $type: $checkedConvert('type', (v) => v as String?),
+      );
+      return val;
+    }, fieldKeyMap: const {r'$type': 'type'});
 
-Map<String, dynamic> _$$_TestStartToJson(_$_TestStart instance) =>
-    <String, dynamic>{
-      'time': instance.time,
-      'test': instance.test.toJson(),
-      'type': instance.$type,
-    };
+Map<String, dynamic> _$$_TestStartToJson(_$_TestStart instance) => <String, dynamic>{
+  'time': instance.time,
+  'test': instance.test.toJson(),
+  'type': instance.$type,
+};
 
-_$_Print _$$_PrintFromJson(Map<String, dynamic> json) => $checkedCreate(
-      r'_$_Print',
-      json,
-      ($checkedConvert) {
-        final val = _$_Print(
-          time: $checkedConvert('time', (v) => v as int),
-          testId: $checkedConvert('testID', (v) => v as int),
-          messageType: $checkedConvert('messageType', (v) => v as String),
-          message: $checkedConvert('message', (v) => v as String),
-          $type: $checkedConvert('type', (v) => v as String?),
-        );
-        return val;
-      },
-      fieldKeyMap: const {'testId': 'testID', r'$type': 'type'},
-    );
+_$_Print _$$_PrintFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$_Print', json, ($checkedConvert) {
+  final val = _$_Print(
+    time: $checkedConvert('time', (v) => v as int),
+    testId: $checkedConvert('testID', (v) => v as int),
+    messageType: $checkedConvert('messageType', (v) => v as String),
+    message: $checkedConvert('message', (v) => v as String),
+    $type: $checkedConvert('type', (v) => v as String?),
+  );
+  return val;
+}, fieldKeyMap: const {'testId': 'testID', r'$type': 'type'});
 
 Map<String, dynamic> _$$_PrintToJson(_$_Print instance) => <String, dynamic>{
-      'time': instance.time,
-      'testID': instance.testId,
-      'messageType': instance.messageType,
-      'message': instance.message,
-      'type': instance.$type,
-    };
+  'time': instance.time,
+  'testID': instance.testId,
+  'messageType': instance.messageType,
+  'message': instance.message,
+  'type': instance.$type,
+};
 
-_$_Error _$$_ErrorFromJson(Map<String, dynamic> json) => $checkedCreate(
-      r'_$_Error',
-      json,
-      ($checkedConvert) {
-        final val = _$_Error(
-          time: $checkedConvert('time', (v) => v as int),
-          testId: $checkedConvert('testID', (v) => v as int),
-          error: $checkedConvert('error', (v) => v as String),
-          stacktrace: $checkedConvert('stackTrace', (v) => v as String),
-          isFailure: $checkedConvert('isFailure', (v) => v as bool),
-          $type: $checkedConvert('type', (v) => v as String?),
-        );
-        return val;
-      },
-      fieldKeyMap: const {
-        'testId': 'testID',
-        'stacktrace': 'stackTrace',
-        r'$type': 'type'
-      },
-    );
+_$_Error _$$_ErrorFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$_Error', json, ($checkedConvert) {
+  final val = _$_Error(
+    time: $checkedConvert('time', (v) => v as int),
+    testId: $checkedConvert('testID', (v) => v as int),
+    error: $checkedConvert('error', (v) => v as String),
+    stacktrace: $checkedConvert('stackTrace', (v) => v as String),
+    isFailure: $checkedConvert('isFailure', (v) => v as bool),
+    $type: $checkedConvert('type', (v) => v as String?),
+  );
+  return val;
+}, fieldKeyMap: const {'testId': 'testID', 'stacktrace': 'stackTrace', r'$type': 'type'});
 
 Map<String, dynamic> _$$_ErrorToJson(_$_Error instance) => <String, dynamic>{
-      'time': instance.time,
-      'testID': instance.testId,
-      'error': instance.error,
-      'stackTrace': instance.stacktrace,
-      'isFailure': instance.isFailure,
-      'type': instance.$type,
-    };
+  'time': instance.time,
+  'testID': instance.testId,
+  'error': instance.error,
+  'stackTrace': instance.stacktrace,
+  'isFailure': instance.isFailure,
+  'type': instance.$type,
+};
 
-_$_TestDone _$$_TestDoneFromJson(Map<String, dynamic> json) => $checkedCreate(
-      r'_$_TestDone',
-      json,
-      ($checkedConvert) {
-        final val = _$_TestDone(
-          time: $checkedConvert('time', (v) => v as int),
-          result: $checkedConvert(
-              'result',
-              (v) => $enumDecode(_$TestResultEnumMap, v,
-                  unknownValue: TestResult.unknown)),
-          testId: $checkedConvert('testID', (v) => v as int),
-          hidden: $checkedConvert('hidden', (v) => v as bool),
-          skipped: $checkedConvert('skipped', (v) => v as bool),
-          $type: $checkedConvert('type', (v) => v as String?),
-        );
-        return val;
-      },
-      fieldKeyMap: const {'testId': 'testID', r'$type': 'type'},
-    );
+_$_TestDone _$$_TestDoneFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$_TestDone', json, ($checkedConvert) {
+  final val = _$_TestDone(
+    time: $checkedConvert('time', (v) => v as int),
+    result: $checkedConvert('result', (v) => $enumDecode(_$TestResultEnumMap, v, unknownValue: TestResult.unknown)),
+    testId: $checkedConvert('testID', (v) => v as int),
+    hidden: $checkedConvert('hidden', (v) => v as bool),
+    skipped: $checkedConvert('skipped', (v) => v as bool),
+    $type: $checkedConvert('type', (v) => v as String?),
+  );
+  return val;
+}, fieldKeyMap: const {'testId': 'testID', r'$type': 'type'});
 
-Map<String, dynamic> _$$_TestDoneToJson(_$_TestDone instance) =>
-    <String, dynamic>{
-      'time': instance.time,
-      'result': _$TestResultEnumMap[instance.result]!,
-      'testID': instance.testId,
-      'hidden': instance.hidden,
-      'skipped': instance.skipped,
-      'type': instance.$type,
-    };
+Map<String, dynamic> _$$_TestDoneToJson(_$_TestDone instance) => <String, dynamic>{
+  'time': instance.time,
+  'result': _$TestResultEnumMap[instance.result]!,
+  'testID': instance.testId,
+  'hidden': instance.hidden,
+  'skipped': instance.skipped,
+  'type': instance.$type,
+};
 
 const _$TestResultEnumMap = {
   TestResult.success: 'success',
@@ -234,41 +176,30 @@ const _$TestResultEnumMap = {
   TestResult.unknown: 'unknown',
 };
 
-_$_Done _$$_DoneFromJson(Map<String, dynamic> json) => $checkedCreate(
-      r'_$_Done',
-      json,
-      ($checkedConvert) {
-        final val = _$_Done(
-          time: $checkedConvert('time', (v) => v as int),
-          success: $checkedConvert('success', (v) => v as bool?),
-          $type: $checkedConvert('type', (v) => v as String?),
-        );
-        return val;
-      },
-      fieldKeyMap: const {r'$type': 'type'},
-    );
+_$_Done _$$_DoneFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$_Done', json, ($checkedConvert) {
+  final val = _$_Done(
+    time: $checkedConvert('time', (v) => v as int),
+    success: $checkedConvert('success', (v) => v as bool?),
+    $type: $checkedConvert('type', (v) => v as String?),
+  );
+  return val;
+}, fieldKeyMap: const {r'$type': 'type'});
 
 Map<String, dynamic> _$$_DoneToJson(_$_Done instance) => <String, dynamic>{
-      'time': instance.time,
-      'success': instance.success,
-      'type': instance.$type,
-    };
+  'time': instance.time,
+  'success': instance.success,
+  'type': instance.$type,
+};
 
-_$_Unknown _$$_UnknownFromJson(Map<String, dynamic> json) => $checkedCreate(
-      r'_$_Unknown',
-      json,
-      ($checkedConvert) {
-        final val = _$_Unknown(
-          time: $checkedConvert('time', (v) => v as int),
-          $type: $checkedConvert('type', (v) => v as String?),
-        );
-        return val;
-      },
-      fieldKeyMap: const {r'$type': 'type'},
-    );
+_$_Unknown _$$_UnknownFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$_Unknown', json, ($checkedConvert) {
+  final val = _$_Unknown(
+    time: $checkedConvert('time', (v) => v as int),
+    $type: $checkedConvert('type', (v) => v as String?),
+  );
+  return val;
+}, fieldKeyMap: const {r'$type': 'type'});
 
-Map<String, dynamic> _$$_UnknownToJson(_$_Unknown instance) =>
-    <String, dynamic>{
-      'time': instance.time,
-      'type': instance.$type,
-    };
+Map<String, dynamic> _$$_UnknownToJson(_$_Unknown instance) => <String, dynamic>{
+  'time': instance.time,
+  'type': instance.$type,
+};

--- a/lib/src/parser/json_reporter_protocol_0_1/group.freezed.dart
+++ b/lib/src/parser/json_reporter_protocol_0_1/group.freezed.dart
@@ -12,7 +12,8 @@ part of 'group.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods',
+);
 
 Group _$GroupFromJson(Map<String, dynamic> json) {
   return _Group.fromJson(json);
@@ -53,17 +54,17 @@ mixin _$Group {
 
 /// @nodoc
 abstract class $GroupCopyWith<$Res> {
-  factory $GroupCopyWith(Group value, $Res Function(Group) then) =
-      _$GroupCopyWithImpl<$Res>;
-  $Res call(
-      {int id,
-      String name,
-      @JsonKey(name: 'suiteID') int suiteId,
-      @JsonKey(name: 'parentID') int? parentId,
-      int testCount,
-      int? line,
-      int? column,
-      String? url});
+  factory $GroupCopyWith(Group value, $Res Function(Group) then) = _$GroupCopyWithImpl<$Res>;
+  $Res call({
+    int id,
+    String name,
+    @JsonKey(name: 'suiteID') int suiteId,
+    @JsonKey(name: 'parentID') int? parentId,
+    int testCount,
+    int? line,
+    int? column,
+    String? url,
+  });
 }
 
 /// @nodoc
@@ -85,64 +86,72 @@ class _$GroupCopyWithImpl<$Res> implements $GroupCopyWith<$Res> {
     Object? column = freezed,
     Object? url = freezed,
   }) {
-    return _then(_value.copyWith(
-      id: id == freezed
-          ? _value.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as int,
-      name: name == freezed
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      suiteId: suiteId == freezed
-          ? _value.suiteId
-          : suiteId // ignore: cast_nullable_to_non_nullable
-              as int,
-      parentId: parentId == freezed
-          ? _value.parentId
-          : parentId // ignore: cast_nullable_to_non_nullable
-              as int?,
-      testCount: testCount == freezed
-          ? _value.testCount
-          : testCount // ignore: cast_nullable_to_non_nullable
-              as int,
-      line: line == freezed
-          ? _value.line
-          : line // ignore: cast_nullable_to_non_nullable
-              as int?,
-      column: column == freezed
-          ? _value.column
-          : column // ignore: cast_nullable_to_non_nullable
-              as int?,
-      url: url == freezed
-          ? _value.url
-          : url // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
+    return _then(
+      _value.copyWith(
+        id:
+            id == freezed
+                ? _value.id
+                : id // ignore: cast_nullable_to_non_nullable
+                    as int,
+        name:
+            name == freezed
+                ? _value.name
+                : name // ignore: cast_nullable_to_non_nullable
+                    as String,
+        suiteId:
+            suiteId == freezed
+                ? _value.suiteId
+                : suiteId // ignore: cast_nullable_to_non_nullable
+                    as int,
+        parentId:
+            parentId == freezed
+                ? _value.parentId
+                : parentId // ignore: cast_nullable_to_non_nullable
+                    as int?,
+        testCount:
+            testCount == freezed
+                ? _value.testCount
+                : testCount // ignore: cast_nullable_to_non_nullable
+                    as int,
+        line:
+            line == freezed
+                ? _value.line
+                : line // ignore: cast_nullable_to_non_nullable
+                    as int?,
+        column:
+            column == freezed
+                ? _value.column
+                : column // ignore: cast_nullable_to_non_nullable
+                    as int?,
+        url:
+            url == freezed
+                ? _value.url
+                : url // ignore: cast_nullable_to_non_nullable
+                    as String?,
+      ),
+    );
   }
 }
 
 /// @nodoc
 abstract class _$$_GroupCopyWith<$Res> implements $GroupCopyWith<$Res> {
-  factory _$$_GroupCopyWith(_$_Group value, $Res Function(_$_Group) then) =
-      __$$_GroupCopyWithImpl<$Res>;
+  factory _$$_GroupCopyWith(_$_Group value, $Res Function(_$_Group) then) = __$$_GroupCopyWithImpl<$Res>;
   @override
-  $Res call(
-      {int id,
-      String name,
-      @JsonKey(name: 'suiteID') int suiteId,
-      @JsonKey(name: 'parentID') int? parentId,
-      int testCount,
-      int? line,
-      int? column,
-      String? url});
+  $Res call({
+    int id,
+    String name,
+    @JsonKey(name: 'suiteID') int suiteId,
+    @JsonKey(name: 'parentID') int? parentId,
+    int testCount,
+    int? line,
+    int? column,
+    String? url,
+  });
 }
 
 /// @nodoc
-class __$$_GroupCopyWithImpl<$Res> extends _$GroupCopyWithImpl<$Res>
-    implements _$$_GroupCopyWith<$Res> {
-  __$$_GroupCopyWithImpl(_$_Group _value, $Res Function(_$_Group) _then)
-      : super(_value, (v) => _then(v as _$_Group));
+class __$$_GroupCopyWithImpl<$Res> extends _$GroupCopyWithImpl<$Res> implements _$$_GroupCopyWith<$Res> {
+  __$$_GroupCopyWithImpl(_$_Group _value, $Res Function(_$_Group) _then) : super(_value, (v) => _then(v as _$_Group));
 
   @override
   _$_Group get _value => super._value as _$_Group;
@@ -158,58 +167,68 @@ class __$$_GroupCopyWithImpl<$Res> extends _$GroupCopyWithImpl<$Res>
     Object? column = freezed,
     Object? url = freezed,
   }) {
-    return _then(_$_Group(
-      id: id == freezed
-          ? _value.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as int,
-      name: name == freezed
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      suiteId: suiteId == freezed
-          ? _value.suiteId
-          : suiteId // ignore: cast_nullable_to_non_nullable
-              as int,
-      parentId: parentId == freezed
-          ? _value.parentId
-          : parentId // ignore: cast_nullable_to_non_nullable
-              as int?,
-      testCount: testCount == freezed
-          ? _value.testCount
-          : testCount // ignore: cast_nullable_to_non_nullable
-              as int,
-      line: line == freezed
-          ? _value.line
-          : line // ignore: cast_nullable_to_non_nullable
-              as int?,
-      column: column == freezed
-          ? _value.column
-          : column // ignore: cast_nullable_to_non_nullable
-              as int?,
-      url: url == freezed
-          ? _value.url
-          : url // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
+    return _then(
+      _$_Group(
+        id:
+            id == freezed
+                ? _value.id
+                : id // ignore: cast_nullable_to_non_nullable
+                    as int,
+        name:
+            name == freezed
+                ? _value.name
+                : name // ignore: cast_nullable_to_non_nullable
+                    as String,
+        suiteId:
+            suiteId == freezed
+                ? _value.suiteId
+                : suiteId // ignore: cast_nullable_to_non_nullable
+                    as int,
+        parentId:
+            parentId == freezed
+                ? _value.parentId
+                : parentId // ignore: cast_nullable_to_non_nullable
+                    as int?,
+        testCount:
+            testCount == freezed
+                ? _value.testCount
+                : testCount // ignore: cast_nullable_to_non_nullable
+                    as int,
+        line:
+            line == freezed
+                ? _value.line
+                : line // ignore: cast_nullable_to_non_nullable
+                    as int?,
+        column:
+            column == freezed
+                ? _value.column
+                : column // ignore: cast_nullable_to_non_nullable
+                    as int?,
+        url:
+            url == freezed
+                ? _value.url
+                : url // ignore: cast_nullable_to_non_nullable
+                    as String?,
+      ),
+    );
   }
 }
 
 /// @nodoc
 @JsonSerializable()
 class _$_Group implements _Group {
-  _$_Group(
-      {required this.id,
-      required this.name,
-      @JsonKey(name: 'suiteID') required this.suiteId,
-      @JsonKey(name: 'parentID') this.parentId,
-      required this.testCount,
-      this.line,
-      this.column,
-      this.url});
+  _$_Group({
+    required this.id,
+    required this.name,
+    @JsonKey(name: 'suiteID') required this.suiteId,
+    @JsonKey(name: 'parentID') this.parentId,
+    required this.testCount,
+    this.line,
+    this.column,
+    this.url,
+  });
 
-  factory _$_Group.fromJson(Map<String, dynamic> json) =>
-      _$$_GroupFromJson(json);
+  factory _$_Group.fromJson(Map<String, dynamic> json) => _$$_GroupFromJson(json);
 
   /// An opaque ID for this group.
   @override
@@ -268,78 +287,68 @@ class _$_Group implements _Group {
   @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(id),
-      const DeepCollectionEquality().hash(name),
-      const DeepCollectionEquality().hash(suiteId),
-      const DeepCollectionEquality().hash(parentId),
-      const DeepCollectionEquality().hash(testCount),
-      const DeepCollectionEquality().hash(line),
-      const DeepCollectionEquality().hash(column),
-      const DeepCollectionEquality().hash(url));
+    runtimeType,
+    const DeepCollectionEquality().hash(id),
+    const DeepCollectionEquality().hash(name),
+    const DeepCollectionEquality().hash(suiteId),
+    const DeepCollectionEquality().hash(parentId),
+    const DeepCollectionEquality().hash(testCount),
+    const DeepCollectionEquality().hash(line),
+    const DeepCollectionEquality().hash(column),
+    const DeepCollectionEquality().hash(url),
+  );
 
   @JsonKey(ignore: true)
   @override
-  _$$_GroupCopyWith<_$_Group> get copyWith =>
-      __$$_GroupCopyWithImpl<_$_Group>(this, _$identity);
+  _$$_GroupCopyWith<_$_Group> get copyWith => __$$_GroupCopyWithImpl<_$_Group>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GroupToJson(
-      this,
-    );
+    return _$$_GroupToJson(this);
   }
 }
 
 abstract class _Group implements Group {
-  factory _Group(
-      {required final int id,
-      required final String name,
-      @JsonKey(name: 'suiteID') required final int suiteId,
-      @JsonKey(name: 'parentID') final int? parentId,
-      required final int testCount,
-      final int? line,
-      final int? column,
-      final String? url}) = _$_Group;
+  factory _Group({
+    required final int id,
+    required final String name,
+    @JsonKey(name: 'suiteID') required final int suiteId,
+    @JsonKey(name: 'parentID') final int? parentId,
+    required final int testCount,
+    final int? line,
+    final int? column,
+    final String? url,
+  }) = _$_Group;
 
   factory _Group.fromJson(Map<String, dynamic> json) = _$_Group.fromJson;
 
   @override
-
   /// An opaque ID for this group.
   int get id;
   @override
-
   /// The name of this group, including prefixes from any containing groups.
   String get name;
   @override
-
   /// The ID of the suite containing this group.
   @JsonKey(name: 'suiteID')
   int get suiteId;
   @override
-
   /// The ID of this group's parent group, unless it's the root group.
   @JsonKey(name: 'parentID')
   int? get parentId;
   @override
-
   /// The number of tests (recursively) within this group.
   int get testCount;
   @override
-
   /// The (1-based) line on which this group was defined, or `null`.
   int? get line;
   @override
-
   /// The (1-based) column on which this group was defined, or `null`.
   int? get column;
   @override
-
   /// The URL for the file in which this group was defined, or `null`.
   String? get url;
   @override
   @JsonKey(ignore: true)
-  _$$_GroupCopyWith<_$_Group> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$_GroupCopyWith<_$_Group> get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/parser/json_reporter_protocol_0_1/group.freezed.dart
+++ b/lib/src/parser/json_reporter_protocol_0_1/group.freezed.dart
@@ -1,7 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
-// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
 part of 'group.dart';
 
@@ -12,7 +12,7 @@ part of 'group.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods',
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
 );
 
 Group _$GroupFromJson(Map<String, dynamic> json) {
@@ -47,14 +47,20 @@ mixin _$Group {
   /// The URL for the file in which this group was defined, or `null`.
   String? get url => throw _privateConstructorUsedError;
 
+  /// Serializes this Group to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of Group
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $GroupCopyWith<Group> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class $GroupCopyWith<$Res> {
-  factory $GroupCopyWith(Group value, $Res Function(Group) then) = _$GroupCopyWithImpl<$Res>;
+  factory $GroupCopyWith(Group value, $Res Function(Group) then) =
+      _$GroupCopyWithImpl<$Res, Group>;
+  @useResult
   $Res call({
     int id,
     String name,
@@ -68,75 +74,85 @@ abstract class $GroupCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$GroupCopyWithImpl<$Res> implements $GroupCopyWith<$Res> {
+class _$GroupCopyWithImpl<$Res, $Val extends Group>
+    implements $GroupCopyWith<$Res> {
   _$GroupCopyWithImpl(this._value, this._then);
 
-  final Group _value;
   // ignore: unused_field
-  final $Res Function(Group) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  /// Create a copy of Group
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? id = freezed,
-    Object? name = freezed,
-    Object? suiteId = freezed,
+    Object? id = null,
+    Object? name = null,
+    Object? suiteId = null,
     Object? parentId = freezed,
-    Object? testCount = freezed,
+    Object? testCount = null,
     Object? line = freezed,
     Object? column = freezed,
     Object? url = freezed,
   }) {
     return _then(
       _value.copyWith(
-        id:
-            id == freezed
-                ? _value.id
-                : id // ignore: cast_nullable_to_non_nullable
-                    as int,
-        name:
-            name == freezed
-                ? _value.name
-                : name // ignore: cast_nullable_to_non_nullable
-                    as String,
-        suiteId:
-            suiteId == freezed
-                ? _value.suiteId
-                : suiteId // ignore: cast_nullable_to_non_nullable
-                    as int,
-        parentId:
-            parentId == freezed
-                ? _value.parentId
-                : parentId // ignore: cast_nullable_to_non_nullable
-                    as int?,
-        testCount:
-            testCount == freezed
-                ? _value.testCount
-                : testCount // ignore: cast_nullable_to_non_nullable
-                    as int,
-        line:
-            line == freezed
-                ? _value.line
-                : line // ignore: cast_nullable_to_non_nullable
-                    as int?,
-        column:
-            column == freezed
-                ? _value.column
-                : column // ignore: cast_nullable_to_non_nullable
-                    as int?,
-        url:
-            url == freezed
-                ? _value.url
-                : url // ignore: cast_nullable_to_non_nullable
-                    as String?,
-      ),
+            id:
+                null == id
+                    ? _value.id
+                    : id // ignore: cast_nullable_to_non_nullable
+                        as int,
+            name:
+                null == name
+                    ? _value.name
+                    : name // ignore: cast_nullable_to_non_nullable
+                        as String,
+            suiteId:
+                null == suiteId
+                    ? _value.suiteId
+                    : suiteId // ignore: cast_nullable_to_non_nullable
+                        as int,
+            parentId:
+                freezed == parentId
+                    ? _value.parentId
+                    : parentId // ignore: cast_nullable_to_non_nullable
+                        as int?,
+            testCount:
+                null == testCount
+                    ? _value.testCount
+                    : testCount // ignore: cast_nullable_to_non_nullable
+                        as int,
+            line:
+                freezed == line
+                    ? _value.line
+                    : line // ignore: cast_nullable_to_non_nullable
+                        as int?,
+            column:
+                freezed == column
+                    ? _value.column
+                    : column // ignore: cast_nullable_to_non_nullable
+                        as int?,
+            url:
+                freezed == url
+                    ? _value.url
+                    : url // ignore: cast_nullable_to_non_nullable
+                        as String?,
+          )
+          as $Val,
     );
   }
 }
 
 /// @nodoc
-abstract class _$$_GroupCopyWith<$Res> implements $GroupCopyWith<$Res> {
-  factory _$$_GroupCopyWith(_$_Group value, $Res Function(_$_Group) then) = __$$_GroupCopyWithImpl<$Res>;
+abstract class _$$GroupImplCopyWith<$Res> implements $GroupCopyWith<$Res> {
+  factory _$$GroupImplCopyWith(
+    _$GroupImpl value,
+    $Res Function(_$GroupImpl) then,
+  ) = __$$GroupImplCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call({
     int id,
     String name,
@@ -150,62 +166,67 @@ abstract class _$$_GroupCopyWith<$Res> implements $GroupCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_GroupCopyWithImpl<$Res> extends _$GroupCopyWithImpl<$Res> implements _$$_GroupCopyWith<$Res> {
-  __$$_GroupCopyWithImpl(_$_Group _value, $Res Function(_$_Group) _then) : super(_value, (v) => _then(v as _$_Group));
+class __$$GroupImplCopyWithImpl<$Res>
+    extends _$GroupCopyWithImpl<$Res, _$GroupImpl>
+    implements _$$GroupImplCopyWith<$Res> {
+  __$$GroupImplCopyWithImpl(
+    _$GroupImpl _value,
+    $Res Function(_$GroupImpl) _then,
+  ) : super(_value, _then);
 
-  @override
-  _$_Group get _value => super._value as _$_Group;
-
+  /// Create a copy of Group
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? id = freezed,
-    Object? name = freezed,
-    Object? suiteId = freezed,
+    Object? id = null,
+    Object? name = null,
+    Object? suiteId = null,
     Object? parentId = freezed,
-    Object? testCount = freezed,
+    Object? testCount = null,
     Object? line = freezed,
     Object? column = freezed,
     Object? url = freezed,
   }) {
     return _then(
-      _$_Group(
+      _$GroupImpl(
         id:
-            id == freezed
+            null == id
                 ? _value.id
                 : id // ignore: cast_nullable_to_non_nullable
                     as int,
         name:
-            name == freezed
+            null == name
                 ? _value.name
                 : name // ignore: cast_nullable_to_non_nullable
                     as String,
         suiteId:
-            suiteId == freezed
+            null == suiteId
                 ? _value.suiteId
                 : suiteId // ignore: cast_nullable_to_non_nullable
                     as int,
         parentId:
-            parentId == freezed
+            freezed == parentId
                 ? _value.parentId
                 : parentId // ignore: cast_nullable_to_non_nullable
                     as int?,
         testCount:
-            testCount == freezed
+            null == testCount
                 ? _value.testCount
                 : testCount // ignore: cast_nullable_to_non_nullable
                     as int,
         line:
-            line == freezed
+            freezed == line
                 ? _value.line
                 : line // ignore: cast_nullable_to_non_nullable
                     as int?,
         column:
-            column == freezed
+            freezed == column
                 ? _value.column
                 : column // ignore: cast_nullable_to_non_nullable
                     as int?,
         url:
-            url == freezed
+            freezed == url
                 ? _value.url
                 : url // ignore: cast_nullable_to_non_nullable
                     as String?,
@@ -216,8 +237,8 @@ class __$$_GroupCopyWithImpl<$Res> extends _$GroupCopyWithImpl<$Res> implements 
 
 /// @nodoc
 @JsonSerializable()
-class _$_Group implements _Group {
-  _$_Group({
+class _$GroupImpl implements _Group {
+  _$GroupImpl({
     required this.id,
     required this.name,
     @JsonKey(name: 'suiteID') required this.suiteId,
@@ -228,7 +249,8 @@ class _$_Group implements _Group {
     this.url,
   });
 
-  factory _$_Group.fromJson(Map<String, dynamic> json) => _$$_GroupFromJson(json);
+  factory _$GroupImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GroupImplFromJson(json);
 
   /// An opaque ID for this group.
   @override
@@ -270,41 +292,47 @@ class _$_Group implements _Group {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Group &&
-            const DeepCollectionEquality().equals(other.id, id) &&
-            const DeepCollectionEquality().equals(other.name, name) &&
-            const DeepCollectionEquality().equals(other.suiteId, suiteId) &&
-            const DeepCollectionEquality().equals(other.parentId, parentId) &&
-            const DeepCollectionEquality().equals(other.testCount, testCount) &&
-            const DeepCollectionEquality().equals(other.line, line) &&
-            const DeepCollectionEquality().equals(other.column, column) &&
-            const DeepCollectionEquality().equals(other.url, url));
+            other is _$GroupImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.suiteId, suiteId) || other.suiteId == suiteId) &&
+            (identical(other.parentId, parentId) ||
+                other.parentId == parentId) &&
+            (identical(other.testCount, testCount) ||
+                other.testCount == testCount) &&
+            (identical(other.line, line) || other.line == line) &&
+            (identical(other.column, column) || other.column == column) &&
+            (identical(other.url, url) || other.url == url));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
     runtimeType,
-    const DeepCollectionEquality().hash(id),
-    const DeepCollectionEquality().hash(name),
-    const DeepCollectionEquality().hash(suiteId),
-    const DeepCollectionEquality().hash(parentId),
-    const DeepCollectionEquality().hash(testCount),
-    const DeepCollectionEquality().hash(line),
-    const DeepCollectionEquality().hash(column),
-    const DeepCollectionEquality().hash(url),
+    id,
+    name,
+    suiteId,
+    parentId,
+    testCount,
+    line,
+    column,
+    url,
   );
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Group
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  _$$_GroupCopyWith<_$_Group> get copyWith => __$$_GroupCopyWithImpl<_$_Group>(this, _$identity);
+  @pragma('vm:prefer-inline')
+  _$$GroupImplCopyWith<_$GroupImpl> get copyWith =>
+      __$$GroupImplCopyWithImpl<_$GroupImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GroupToJson(this);
+    return _$$GroupImplToJson(this);
   }
 }
 
@@ -318,37 +346,48 @@ abstract class _Group implements Group {
     final int? line,
     final int? column,
     final String? url,
-  }) = _$_Group;
+  }) = _$GroupImpl;
 
-  factory _Group.fromJson(Map<String, dynamic> json) = _$_Group.fromJson;
+  factory _Group.fromJson(Map<String, dynamic> json) = _$GroupImpl.fromJson;
 
-  @override
   /// An opaque ID for this group.
+  @override
   int get id;
-  @override
+
   /// The name of this group, including prefixes from any containing groups.
-  String get name;
   @override
+  String get name;
+
   /// The ID of the suite containing this group.
+  @override
   @JsonKey(name: 'suiteID')
   int get suiteId;
-  @override
+
   /// The ID of this group's parent group, unless it's the root group.
+  @override
   @JsonKey(name: 'parentID')
   int? get parentId;
-  @override
+
   /// The number of tests (recursively) within this group.
+  @override
   int get testCount;
-  @override
+
   /// The (1-based) line on which this group was defined, or `null`.
+  @override
   int? get line;
-  @override
+
   /// The (1-based) column on which this group was defined, or `null`.
+  @override
   int? get column;
-  @override
+
   /// The URL for the file in which this group was defined, or `null`.
-  String? get url;
   @override
-  @JsonKey(ignore: true)
-  _$$_GroupCopyWith<_$_Group> get copyWith => throw _privateConstructorUsedError;
+  String? get url;
+
+  /// Create a copy of Group
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$GroupImplCopyWith<_$GroupImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }

--- a/lib/src/parser/json_reporter_protocol_0_1/group.freezed.dart
+++ b/lib/src/parser/json_reporter_protocol_0_1/group.freezed.dart
@@ -58,8 +58,7 @@ mixin _$Group {
 
 /// @nodoc
 abstract class $GroupCopyWith<$Res> {
-  factory $GroupCopyWith(Group value, $Res Function(Group) then) =
-      _$GroupCopyWithImpl<$Res, Group>;
+  factory $GroupCopyWith(Group value, $Res Function(Group) then) = _$GroupCopyWithImpl<$Res, Group>;
   @useResult
   $Res call({
     int id,
@@ -74,8 +73,7 @@ abstract class $GroupCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$GroupCopyWithImpl<$Res, $Val extends Group>
-    implements $GroupCopyWith<$Res> {
+class _$GroupCopyWithImpl<$Res, $Val extends Group> implements $GroupCopyWith<$Res> {
   _$GroupCopyWithImpl(this._value, this._then);
 
   // ignore: unused_field
@@ -147,10 +145,7 @@ class _$GroupCopyWithImpl<$Res, $Val extends Group>
 
 /// @nodoc
 abstract class _$$GroupImplCopyWith<$Res> implements $GroupCopyWith<$Res> {
-  factory _$$GroupImplCopyWith(
-    _$GroupImpl value,
-    $Res Function(_$GroupImpl) then,
-  ) = __$$GroupImplCopyWithImpl<$Res>;
+  factory _$$GroupImplCopyWith(_$GroupImpl value, $Res Function(_$GroupImpl) then) = __$$GroupImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({
@@ -166,13 +161,9 @@ abstract class _$$GroupImplCopyWith<$Res> implements $GroupCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$GroupImplCopyWithImpl<$Res>
-    extends _$GroupCopyWithImpl<$Res, _$GroupImpl>
+class __$$GroupImplCopyWithImpl<$Res> extends _$GroupCopyWithImpl<$Res, _$GroupImpl>
     implements _$$GroupImplCopyWith<$Res> {
-  __$$GroupImplCopyWithImpl(
-    _$GroupImpl _value,
-    $Res Function(_$GroupImpl) _then,
-  ) : super(_value, _then);
+  __$$GroupImplCopyWithImpl(_$GroupImpl _value, $Res Function(_$GroupImpl) _then) : super(_value, _then);
 
   /// Create a copy of Group
   /// with the given fields replaced by the non-null parameter values.
@@ -249,8 +240,7 @@ class _$GroupImpl implements _Group {
     this.url,
   });
 
-  factory _$GroupImpl.fromJson(Map<String, dynamic> json) =>
-      _$$GroupImplFromJson(json);
+  factory _$GroupImpl.fromJson(Map<String, dynamic> json) => _$$GroupImplFromJson(json);
 
   /// An opaque ID for this group.
   @override
@@ -299,10 +289,8 @@ class _$GroupImpl implements _Group {
             (identical(other.id, id) || other.id == id) &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.suiteId, suiteId) || other.suiteId == suiteId) &&
-            (identical(other.parentId, parentId) ||
-                other.parentId == parentId) &&
-            (identical(other.testCount, testCount) ||
-                other.testCount == testCount) &&
+            (identical(other.parentId, parentId) || other.parentId == parentId) &&
+            (identical(other.testCount, testCount) || other.testCount == testCount) &&
             (identical(other.line, line) || other.line == line) &&
             (identical(other.column, column) || other.column == column) &&
             (identical(other.url, url) || other.url == url));
@@ -310,25 +298,14 @@ class _$GroupImpl implements _Group {
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(
-    runtimeType,
-    id,
-    name,
-    suiteId,
-    parentId,
-    testCount,
-    line,
-    column,
-    url,
-  );
+  int get hashCode => Object.hash(runtimeType, id, name, suiteId, parentId, testCount, line, column, url);
 
   /// Create a copy of Group
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$GroupImplCopyWith<_$GroupImpl> get copyWith =>
-      __$$GroupImplCopyWithImpl<_$GroupImpl>(this, _$identity);
+  _$$GroupImplCopyWith<_$GroupImpl> get copyWith => __$$GroupImplCopyWithImpl<_$GroupImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
@@ -388,6 +365,5 @@ abstract class _Group implements Group {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$GroupImplCopyWith<_$GroupImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$GroupImplCopyWith<_$GroupImpl> get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/parser/json_reporter_protocol_0_1/group.freezed.dart
+++ b/lib/src/parser/json_reporter_protocol_0_1/group.freezed.dart
@@ -58,7 +58,8 @@ mixin _$Group {
 
 /// @nodoc
 abstract class $GroupCopyWith<$Res> {
-  factory $GroupCopyWith(Group value, $Res Function(Group) then) = _$GroupCopyWithImpl<$Res, Group>;
+  factory $GroupCopyWith(Group value, $Res Function(Group) then) =
+      _$GroupCopyWithImpl<$Res, Group>;
   @useResult
   $Res call({
     int id,
@@ -73,7 +74,8 @@ abstract class $GroupCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$GroupCopyWithImpl<$Res, $Val extends Group> implements $GroupCopyWith<$Res> {
+class _$GroupCopyWithImpl<$Res, $Val extends Group>
+    implements $GroupCopyWith<$Res> {
   _$GroupCopyWithImpl(this._value, this._then);
 
   // ignore: unused_field
@@ -145,7 +147,10 @@ class _$GroupCopyWithImpl<$Res, $Val extends Group> implements $GroupCopyWith<$R
 
 /// @nodoc
 abstract class _$$GroupImplCopyWith<$Res> implements $GroupCopyWith<$Res> {
-  factory _$$GroupImplCopyWith(_$GroupImpl value, $Res Function(_$GroupImpl) then) = __$$GroupImplCopyWithImpl<$Res>;
+  factory _$$GroupImplCopyWith(
+    _$GroupImpl value,
+    $Res Function(_$GroupImpl) then,
+  ) = __$$GroupImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({
@@ -161,9 +166,13 @@ abstract class _$$GroupImplCopyWith<$Res> implements $GroupCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$GroupImplCopyWithImpl<$Res> extends _$GroupCopyWithImpl<$Res, _$GroupImpl>
+class __$$GroupImplCopyWithImpl<$Res>
+    extends _$GroupCopyWithImpl<$Res, _$GroupImpl>
     implements _$$GroupImplCopyWith<$Res> {
-  __$$GroupImplCopyWithImpl(_$GroupImpl _value, $Res Function(_$GroupImpl) _then) : super(_value, _then);
+  __$$GroupImplCopyWithImpl(
+    _$GroupImpl _value,
+    $Res Function(_$GroupImpl) _then,
+  ) : super(_value, _then);
 
   /// Create a copy of Group
   /// with the given fields replaced by the non-null parameter values.
@@ -240,7 +249,8 @@ class _$GroupImpl implements _Group {
     this.url,
   });
 
-  factory _$GroupImpl.fromJson(Map<String, dynamic> json) => _$$GroupImplFromJson(json);
+  factory _$GroupImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GroupImplFromJson(json);
 
   /// An opaque ID for this group.
   @override
@@ -289,8 +299,10 @@ class _$GroupImpl implements _Group {
             (identical(other.id, id) || other.id == id) &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.suiteId, suiteId) || other.suiteId == suiteId) &&
-            (identical(other.parentId, parentId) || other.parentId == parentId) &&
-            (identical(other.testCount, testCount) || other.testCount == testCount) &&
+            (identical(other.parentId, parentId) ||
+                other.parentId == parentId) &&
+            (identical(other.testCount, testCount) ||
+                other.testCount == testCount) &&
             (identical(other.line, line) || other.line == line) &&
             (identical(other.column, column) || other.column == column) &&
             (identical(other.url, url) || other.url == url));
@@ -298,14 +310,25 @@ class _$GroupImpl implements _Group {
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(runtimeType, id, name, suiteId, parentId, testCount, line, column, url);
+  int get hashCode => Object.hash(
+    runtimeType,
+    id,
+    name,
+    suiteId,
+    parentId,
+    testCount,
+    line,
+    column,
+    url,
+  );
 
   /// Create a copy of Group
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$GroupImplCopyWith<_$GroupImpl> get copyWith => __$$GroupImplCopyWithImpl<_$GroupImpl>(this, _$identity);
+  _$$GroupImplCopyWith<_$GroupImpl> get copyWith =>
+      __$$GroupImplCopyWithImpl<_$GroupImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
@@ -365,5 +388,6 @@ abstract class _Group implements Group {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$GroupImplCopyWith<_$GroupImpl> get copyWith => throw _privateConstructorUsedError;
+  _$$GroupImplCopyWith<_$GroupImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }

--- a/lib/src/parser/json_reporter_protocol_0_1/group.g.dart
+++ b/lib/src/parser/json_reporter_protocol_0_1/group.g.dart
@@ -8,27 +8,33 @@ part of 'group.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_Group _$$_GroupFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$_Group', json, ($checkedConvert) {
-  final val = _$_Group(
-    id: $checkedConvert('id', (v) => v as int),
-    name: $checkedConvert('name', (v) => v as String),
-    suiteId: $checkedConvert('suiteID', (v) => v as int),
-    parentId: $checkedConvert('parentID', (v) => v as int?),
-    testCount: $checkedConvert('testCount', (v) => v as int),
-    line: $checkedConvert('line', (v) => v as int?),
-    column: $checkedConvert('column', (v) => v as int?),
-    url: $checkedConvert('url', (v) => v as String?),
-  );
-  return val;
-}, fieldKeyMap: const {'suiteId': 'suiteID', 'parentId': 'parentID'});
+_$GroupImpl _$$GroupImplFromJson(Map<String, dynamic> json) => $checkedCreate(
+  r'_$GroupImpl',
+  json,
+  ($checkedConvert) {
+    final val = _$GroupImpl(
+      id: $checkedConvert('id', (v) => (v as num).toInt()),
+      name: $checkedConvert('name', (v) => v as String),
+      suiteId: $checkedConvert('suiteID', (v) => (v as num).toInt()),
+      parentId: $checkedConvert('parentID', (v) => (v as num?)?.toInt()),
+      testCount: $checkedConvert('testCount', (v) => (v as num).toInt()),
+      line: $checkedConvert('line', (v) => (v as num?)?.toInt()),
+      column: $checkedConvert('column', (v) => (v as num?)?.toInt()),
+      url: $checkedConvert('url', (v) => v as String?),
+    );
+    return val;
+  },
+  fieldKeyMap: const {'suiteId': 'suiteID', 'parentId': 'parentID'},
+);
 
-Map<String, dynamic> _$$_GroupToJson(_$_Group instance) => <String, dynamic>{
-  'id': instance.id,
-  'name': instance.name,
-  'suiteID': instance.suiteId,
-  'parentID': instance.parentId,
-  'testCount': instance.testCount,
-  'line': instance.line,
-  'column': instance.column,
-  'url': instance.url,
-};
+Map<String, dynamic> _$$GroupImplToJson(_$GroupImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'suiteID': instance.suiteId,
+      'parentID': instance.parentId,
+      'testCount': instance.testCount,
+      'line': instance.line,
+      'column': instance.column,
+      'url': instance.url,
+    };

--- a/lib/src/parser/json_reporter_protocol_0_1/group.g.dart
+++ b/lib/src/parser/json_reporter_protocol_0_1/group.g.dart
@@ -8,32 +8,27 @@ part of 'group.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_Group _$$_GroupFromJson(Map<String, dynamic> json) => $checkedCreate(
-      r'_$_Group',
-      json,
-      ($checkedConvert) {
-        final val = _$_Group(
-          id: $checkedConvert('id', (v) => v as int),
-          name: $checkedConvert('name', (v) => v as String),
-          suiteId: $checkedConvert('suiteID', (v) => v as int),
-          parentId: $checkedConvert('parentID', (v) => v as int?),
-          testCount: $checkedConvert('testCount', (v) => v as int),
-          line: $checkedConvert('line', (v) => v as int?),
-          column: $checkedConvert('column', (v) => v as int?),
-          url: $checkedConvert('url', (v) => v as String?),
-        );
-        return val;
-      },
-      fieldKeyMap: const {'suiteId': 'suiteID', 'parentId': 'parentID'},
-    );
+_$_Group _$$_GroupFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$_Group', json, ($checkedConvert) {
+  final val = _$_Group(
+    id: $checkedConvert('id', (v) => v as int),
+    name: $checkedConvert('name', (v) => v as String),
+    suiteId: $checkedConvert('suiteID', (v) => v as int),
+    parentId: $checkedConvert('parentID', (v) => v as int?),
+    testCount: $checkedConvert('testCount', (v) => v as int),
+    line: $checkedConvert('line', (v) => v as int?),
+    column: $checkedConvert('column', (v) => v as int?),
+    url: $checkedConvert('url', (v) => v as String?),
+  );
+  return val;
+}, fieldKeyMap: const {'suiteId': 'suiteID', 'parentId': 'parentID'});
 
 Map<String, dynamic> _$$_GroupToJson(_$_Group instance) => <String, dynamic>{
-      'id': instance.id,
-      'name': instance.name,
-      'suiteID': instance.suiteId,
-      'parentID': instance.parentId,
-      'testCount': instance.testCount,
-      'line': instance.line,
-      'column': instance.column,
-      'url': instance.url,
-    };
+  'id': instance.id,
+  'name': instance.name,
+  'suiteID': instance.suiteId,
+  'parentID': instance.parentId,
+  'testCount': instance.testCount,
+  'line': instance.line,
+  'column': instance.column,
+  'url': instance.url,
+};

--- a/lib/src/parser/json_reporter_protocol_0_1/group.g.dart
+++ b/lib/src/parser/json_reporter_protocol_0_1/group.g.dart
@@ -8,33 +8,27 @@ part of 'group.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$GroupImpl _$$GroupImplFromJson(Map<String, dynamic> json) => $checkedCreate(
-  r'_$GroupImpl',
-  json,
-  ($checkedConvert) {
-    final val = _$GroupImpl(
-      id: $checkedConvert('id', (v) => (v as num).toInt()),
-      name: $checkedConvert('name', (v) => v as String),
-      suiteId: $checkedConvert('suiteID', (v) => (v as num).toInt()),
-      parentId: $checkedConvert('parentID', (v) => (v as num?)?.toInt()),
-      testCount: $checkedConvert('testCount', (v) => (v as num).toInt()),
-      line: $checkedConvert('line', (v) => (v as num?)?.toInt()),
-      column: $checkedConvert('column', (v) => (v as num?)?.toInt()),
-      url: $checkedConvert('url', (v) => v as String?),
-    );
-    return val;
-  },
-  fieldKeyMap: const {'suiteId': 'suiteID', 'parentId': 'parentID'},
-);
+_$GroupImpl _$$GroupImplFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$GroupImpl', json, ($checkedConvert) {
+  final val = _$GroupImpl(
+    id: $checkedConvert('id', (v) => (v as num).toInt()),
+    name: $checkedConvert('name', (v) => v as String),
+    suiteId: $checkedConvert('suiteID', (v) => (v as num).toInt()),
+    parentId: $checkedConvert('parentID', (v) => (v as num?)?.toInt()),
+    testCount: $checkedConvert('testCount', (v) => (v as num).toInt()),
+    line: $checkedConvert('line', (v) => (v as num?)?.toInt()),
+    column: $checkedConvert('column', (v) => (v as num?)?.toInt()),
+    url: $checkedConvert('url', (v) => v as String?),
+  );
+  return val;
+}, fieldKeyMap: const {'suiteId': 'suiteID', 'parentId': 'parentID'});
 
-Map<String, dynamic> _$$GroupImplToJson(_$GroupImpl instance) =>
-    <String, dynamic>{
-      'id': instance.id,
-      'name': instance.name,
-      'suiteID': instance.suiteId,
-      'parentID': instance.parentId,
-      'testCount': instance.testCount,
-      'line': instance.line,
-      'column': instance.column,
-      'url': instance.url,
-    };
+Map<String, dynamic> _$$GroupImplToJson(_$GroupImpl instance) => <String, dynamic>{
+  'id': instance.id,
+  'name': instance.name,
+  'suiteID': instance.suiteId,
+  'parentID': instance.parentId,
+  'testCount': instance.testCount,
+  'line': instance.line,
+  'column': instance.column,
+  'url': instance.url,
+};

--- a/lib/src/parser/json_reporter_protocol_0_1/group.g.dart
+++ b/lib/src/parser/json_reporter_protocol_0_1/group.g.dart
@@ -8,27 +8,33 @@ part of 'group.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$GroupImpl _$$GroupImplFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$GroupImpl', json, ($checkedConvert) {
-  final val = _$GroupImpl(
-    id: $checkedConvert('id', (v) => (v as num).toInt()),
-    name: $checkedConvert('name', (v) => v as String),
-    suiteId: $checkedConvert('suiteID', (v) => (v as num).toInt()),
-    parentId: $checkedConvert('parentID', (v) => (v as num?)?.toInt()),
-    testCount: $checkedConvert('testCount', (v) => (v as num).toInt()),
-    line: $checkedConvert('line', (v) => (v as num?)?.toInt()),
-    column: $checkedConvert('column', (v) => (v as num?)?.toInt()),
-    url: $checkedConvert('url', (v) => v as String?),
-  );
-  return val;
-}, fieldKeyMap: const {'suiteId': 'suiteID', 'parentId': 'parentID'});
+_$GroupImpl _$$GroupImplFromJson(Map<String, dynamic> json) => $checkedCreate(
+  r'_$GroupImpl',
+  json,
+  ($checkedConvert) {
+    final val = _$GroupImpl(
+      id: $checkedConvert('id', (v) => (v as num).toInt()),
+      name: $checkedConvert('name', (v) => v as String),
+      suiteId: $checkedConvert('suiteID', (v) => (v as num).toInt()),
+      parentId: $checkedConvert('parentID', (v) => (v as num?)?.toInt()),
+      testCount: $checkedConvert('testCount', (v) => (v as num).toInt()),
+      line: $checkedConvert('line', (v) => (v as num?)?.toInt()),
+      column: $checkedConvert('column', (v) => (v as num?)?.toInt()),
+      url: $checkedConvert('url', (v) => v as String?),
+    );
+    return val;
+  },
+  fieldKeyMap: const {'suiteId': 'suiteID', 'parentId': 'parentID'},
+);
 
-Map<String, dynamic> _$$GroupImplToJson(_$GroupImpl instance) => <String, dynamic>{
-  'id': instance.id,
-  'name': instance.name,
-  'suiteID': instance.suiteId,
-  'parentID': instance.parentId,
-  'testCount': instance.testCount,
-  'line': instance.line,
-  'column': instance.column,
-  'url': instance.url,
-};
+Map<String, dynamic> _$$GroupImplToJson(_$GroupImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'suiteID': instance.suiteId,
+      'parentID': instance.parentId,
+      'testCount': instance.testCount,
+      'line': instance.line,
+      'column': instance.column,
+      'url': instance.url,
+    };

--- a/lib/src/parser/json_reporter_protocol_0_1/suite.freezed.dart
+++ b/lib/src/parser/json_reporter_protocol_0_1/suite.freezed.dart
@@ -12,7 +12,8 @@ part of 'suite.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods',
+);
 
 Suite _$SuiteFromJson(Map<String, dynamic> json) {
   return _Suite.fromJson(json);
@@ -36,8 +37,7 @@ mixin _$Suite {
 
 /// @nodoc
 abstract class $SuiteCopyWith<$Res> {
-  factory $SuiteCopyWith(Suite value, $Res Function(Suite) then) =
-      _$SuiteCopyWithImpl<$Res>;
+  factory $SuiteCopyWith(Suite value, $Res Function(Suite) then) = _$SuiteCopyWithImpl<$Res>;
   $Res call({int id, String platform, String? path});
 }
 
@@ -50,65 +50,64 @@ class _$SuiteCopyWithImpl<$Res> implements $SuiteCopyWith<$Res> {
   final $Res Function(Suite) _then;
 
   @override
-  $Res call({
-    Object? id = freezed,
-    Object? platform = freezed,
-    Object? path = freezed,
-  }) {
-    return _then(_value.copyWith(
-      id: id == freezed
-          ? _value.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as int,
-      platform: platform == freezed
-          ? _value.platform
-          : platform // ignore: cast_nullable_to_non_nullable
-              as String,
-      path: path == freezed
-          ? _value.path
-          : path // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
+  $Res call({Object? id = freezed, Object? platform = freezed, Object? path = freezed}) {
+    return _then(
+      _value.copyWith(
+        id:
+            id == freezed
+                ? _value.id
+                : id // ignore: cast_nullable_to_non_nullable
+                    as int,
+        platform:
+            platform == freezed
+                ? _value.platform
+                : platform // ignore: cast_nullable_to_non_nullable
+                    as String,
+        path:
+            path == freezed
+                ? _value.path
+                : path // ignore: cast_nullable_to_non_nullable
+                    as String?,
+      ),
+    );
   }
 }
 
 /// @nodoc
 abstract class _$$_SuiteCopyWith<$Res> implements $SuiteCopyWith<$Res> {
-  factory _$$_SuiteCopyWith(_$_Suite value, $Res Function(_$_Suite) then) =
-      __$$_SuiteCopyWithImpl<$Res>;
+  factory _$$_SuiteCopyWith(_$_Suite value, $Res Function(_$_Suite) then) = __$$_SuiteCopyWithImpl<$Res>;
   @override
   $Res call({int id, String platform, String? path});
 }
 
 /// @nodoc
-class __$$_SuiteCopyWithImpl<$Res> extends _$SuiteCopyWithImpl<$Res>
-    implements _$$_SuiteCopyWith<$Res> {
-  __$$_SuiteCopyWithImpl(_$_Suite _value, $Res Function(_$_Suite) _then)
-      : super(_value, (v) => _then(v as _$_Suite));
+class __$$_SuiteCopyWithImpl<$Res> extends _$SuiteCopyWithImpl<$Res> implements _$$_SuiteCopyWith<$Res> {
+  __$$_SuiteCopyWithImpl(_$_Suite _value, $Res Function(_$_Suite) _then) : super(_value, (v) => _then(v as _$_Suite));
 
   @override
   _$_Suite get _value => super._value as _$_Suite;
 
   @override
-  $Res call({
-    Object? id = freezed,
-    Object? platform = freezed,
-    Object? path = freezed,
-  }) {
-    return _then(_$_Suite(
-      id: id == freezed
-          ? _value.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as int,
-      platform: platform == freezed
-          ? _value.platform
-          : platform // ignore: cast_nullable_to_non_nullable
-              as String,
-      path: path == freezed
-          ? _value.path
-          : path // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
+  $Res call({Object? id = freezed, Object? platform = freezed, Object? path = freezed}) {
+    return _then(
+      _$_Suite(
+        id:
+            id == freezed
+                ? _value.id
+                : id // ignore: cast_nullable_to_non_nullable
+                    as int,
+        platform:
+            platform == freezed
+                ? _value.platform
+                : platform // ignore: cast_nullable_to_non_nullable
+                    as String,
+        path:
+            path == freezed
+                ? _value.path
+                : path // ignore: cast_nullable_to_non_nullable
+                    as String?,
+      ),
+    );
   }
 }
 
@@ -117,8 +116,7 @@ class __$$_SuiteCopyWithImpl<$Res> extends _$SuiteCopyWithImpl<$Res>
 class _$_Suite implements _Suite {
   _$_Suite({required this.id, required this.platform, this.path});
 
-  factory _$_Suite.fromJson(Map<String, dynamic> json) =>
-      _$$_SuiteFromJson(json);
+  factory _$_Suite.fromJson(Map<String, dynamic> json) => _$$_SuiteFromJson(json);
 
   /// An opaque ID for this suite.
   @override
@@ -150,46 +148,37 @@ class _$_Suite implements _Suite {
   @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(id),
-      const DeepCollectionEquality().hash(platform),
-      const DeepCollectionEquality().hash(path));
+    runtimeType,
+    const DeepCollectionEquality().hash(id),
+    const DeepCollectionEquality().hash(platform),
+    const DeepCollectionEquality().hash(path),
+  );
 
   @JsonKey(ignore: true)
   @override
-  _$$_SuiteCopyWith<_$_Suite> get copyWith =>
-      __$$_SuiteCopyWithImpl<_$_Suite>(this, _$identity);
+  _$$_SuiteCopyWith<_$_Suite> get copyWith => __$$_SuiteCopyWithImpl<_$_Suite>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_SuiteToJson(
-      this,
-    );
+    return _$$_SuiteToJson(this);
   }
 }
 
 abstract class _Suite implements Suite {
-  factory _Suite(
-      {required final int id,
-      required final String platform,
-      final String? path}) = _$_Suite;
+  factory _Suite({required final int id, required final String platform, final String? path}) = _$_Suite;
 
   factory _Suite.fromJson(Map<String, dynamic> json) = _$_Suite.fromJson;
 
   @override
-
   /// An opaque ID for this suite.
   int get id;
   @override
-
   /// The platform on which this suite is running.
   String get platform;
   @override
-
   /// The path to this suite's file, or `null` if that path is unknown.
   String? get path;
   @override
   @JsonKey(ignore: true)
-  _$$_SuiteCopyWith<_$_Suite> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$_SuiteCopyWith<_$_Suite> get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/parser/json_reporter_protocol_0_1/suite.freezed.dart
+++ b/lib/src/parser/json_reporter_protocol_0_1/suite.freezed.dart
@@ -41,13 +41,15 @@ mixin _$Suite {
 
 /// @nodoc
 abstract class $SuiteCopyWith<$Res> {
-  factory $SuiteCopyWith(Suite value, $Res Function(Suite) then) = _$SuiteCopyWithImpl<$Res, Suite>;
+  factory $SuiteCopyWith(Suite value, $Res Function(Suite) then) =
+      _$SuiteCopyWithImpl<$Res, Suite>;
   @useResult
   $Res call({int id, String platform, String? path});
 }
 
 /// @nodoc
-class _$SuiteCopyWithImpl<$Res, $Val extends Suite> implements $SuiteCopyWith<$Res> {
+class _$SuiteCopyWithImpl<$Res, $Val extends Suite>
+    implements $SuiteCopyWith<$Res> {
   _$SuiteCopyWithImpl(this._value, this._then);
 
   // ignore: unused_field
@@ -59,7 +61,11 @@ class _$SuiteCopyWithImpl<$Res, $Val extends Suite> implements $SuiteCopyWith<$R
   /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
-  $Res call({Object? id = null, Object? platform = null, Object? path = freezed}) {
+  $Res call({
+    Object? id = null,
+    Object? platform = null,
+    Object? path = freezed,
+  }) {
     return _then(
       _value.copyWith(
             id:
@@ -85,22 +91,33 @@ class _$SuiteCopyWithImpl<$Res, $Val extends Suite> implements $SuiteCopyWith<$R
 
 /// @nodoc
 abstract class _$$SuiteImplCopyWith<$Res> implements $SuiteCopyWith<$Res> {
-  factory _$$SuiteImplCopyWith(_$SuiteImpl value, $Res Function(_$SuiteImpl) then) = __$$SuiteImplCopyWithImpl<$Res>;
+  factory _$$SuiteImplCopyWith(
+    _$SuiteImpl value,
+    $Res Function(_$SuiteImpl) then,
+  ) = __$$SuiteImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int id, String platform, String? path});
 }
 
 /// @nodoc
-class __$$SuiteImplCopyWithImpl<$Res> extends _$SuiteCopyWithImpl<$Res, _$SuiteImpl>
+class __$$SuiteImplCopyWithImpl<$Res>
+    extends _$SuiteCopyWithImpl<$Res, _$SuiteImpl>
     implements _$$SuiteImplCopyWith<$Res> {
-  __$$SuiteImplCopyWithImpl(_$SuiteImpl _value, $Res Function(_$SuiteImpl) _then) : super(_value, _then);
+  __$$SuiteImplCopyWithImpl(
+    _$SuiteImpl _value,
+    $Res Function(_$SuiteImpl) _then,
+  ) : super(_value, _then);
 
   /// Create a copy of Suite
   /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
-  $Res call({Object? id = null, Object? platform = null, Object? path = freezed}) {
+  $Res call({
+    Object? id = null,
+    Object? platform = null,
+    Object? path = freezed,
+  }) {
     return _then(
       _$SuiteImpl(
         id:
@@ -128,7 +145,8 @@ class __$$SuiteImplCopyWithImpl<$Res> extends _$SuiteCopyWithImpl<$Res, _$SuiteI
 class _$SuiteImpl implements _Suite {
   _$SuiteImpl({required this.id, required this.platform, this.path});
 
-  factory _$SuiteImpl.fromJson(Map<String, dynamic> json) => _$$SuiteImplFromJson(json);
+  factory _$SuiteImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SuiteImplFromJson(json);
 
   /// An opaque ID for this suite.
   @override
@@ -153,7 +171,8 @@ class _$SuiteImpl implements _Suite {
         (other.runtimeType == runtimeType &&
             other is _$SuiteImpl &&
             (identical(other.id, id) || other.id == id) &&
-            (identical(other.platform, platform) || other.platform == platform) &&
+            (identical(other.platform, platform) ||
+                other.platform == platform) &&
             (identical(other.path, path) || other.path == path));
   }
 
@@ -166,7 +185,8 @@ class _$SuiteImpl implements _Suite {
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$SuiteImplCopyWith<_$SuiteImpl> get copyWith => __$$SuiteImplCopyWithImpl<_$SuiteImpl>(this, _$identity);
+  _$$SuiteImplCopyWith<_$SuiteImpl> get copyWith =>
+      __$$SuiteImplCopyWithImpl<_$SuiteImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
@@ -175,7 +195,11 @@ class _$SuiteImpl implements _Suite {
 }
 
 abstract class _Suite implements Suite {
-  factory _Suite({required final int id, required final String platform, final String? path}) = _$SuiteImpl;
+  factory _Suite({
+    required final int id,
+    required final String platform,
+    final String? path,
+  }) = _$SuiteImpl;
 
   factory _Suite.fromJson(Map<String, dynamic> json) = _$SuiteImpl.fromJson;
 
@@ -195,5 +219,6 @@ abstract class _Suite implements Suite {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$SuiteImplCopyWith<_$SuiteImpl> get copyWith => throw _privateConstructorUsedError;
+  _$$SuiteImplCopyWith<_$SuiteImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }

--- a/lib/src/parser/json_reporter_protocol_0_1/suite.freezed.dart
+++ b/lib/src/parser/json_reporter_protocol_0_1/suite.freezed.dart
@@ -41,15 +41,13 @@ mixin _$Suite {
 
 /// @nodoc
 abstract class $SuiteCopyWith<$Res> {
-  factory $SuiteCopyWith(Suite value, $Res Function(Suite) then) =
-      _$SuiteCopyWithImpl<$Res, Suite>;
+  factory $SuiteCopyWith(Suite value, $Res Function(Suite) then) = _$SuiteCopyWithImpl<$Res, Suite>;
   @useResult
   $Res call({int id, String platform, String? path});
 }
 
 /// @nodoc
-class _$SuiteCopyWithImpl<$Res, $Val extends Suite>
-    implements $SuiteCopyWith<$Res> {
+class _$SuiteCopyWithImpl<$Res, $Val extends Suite> implements $SuiteCopyWith<$Res> {
   _$SuiteCopyWithImpl(this._value, this._then);
 
   // ignore: unused_field
@@ -61,11 +59,7 @@ class _$SuiteCopyWithImpl<$Res, $Val extends Suite>
   /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
-  $Res call({
-    Object? id = null,
-    Object? platform = null,
-    Object? path = freezed,
-  }) {
+  $Res call({Object? id = null, Object? platform = null, Object? path = freezed}) {
     return _then(
       _value.copyWith(
             id:
@@ -91,33 +85,22 @@ class _$SuiteCopyWithImpl<$Res, $Val extends Suite>
 
 /// @nodoc
 abstract class _$$SuiteImplCopyWith<$Res> implements $SuiteCopyWith<$Res> {
-  factory _$$SuiteImplCopyWith(
-    _$SuiteImpl value,
-    $Res Function(_$SuiteImpl) then,
-  ) = __$$SuiteImplCopyWithImpl<$Res>;
+  factory _$$SuiteImplCopyWith(_$SuiteImpl value, $Res Function(_$SuiteImpl) then) = __$$SuiteImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int id, String platform, String? path});
 }
 
 /// @nodoc
-class __$$SuiteImplCopyWithImpl<$Res>
-    extends _$SuiteCopyWithImpl<$Res, _$SuiteImpl>
+class __$$SuiteImplCopyWithImpl<$Res> extends _$SuiteCopyWithImpl<$Res, _$SuiteImpl>
     implements _$$SuiteImplCopyWith<$Res> {
-  __$$SuiteImplCopyWithImpl(
-    _$SuiteImpl _value,
-    $Res Function(_$SuiteImpl) _then,
-  ) : super(_value, _then);
+  __$$SuiteImplCopyWithImpl(_$SuiteImpl _value, $Res Function(_$SuiteImpl) _then) : super(_value, _then);
 
   /// Create a copy of Suite
   /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
-  $Res call({
-    Object? id = null,
-    Object? platform = null,
-    Object? path = freezed,
-  }) {
+  $Res call({Object? id = null, Object? platform = null, Object? path = freezed}) {
     return _then(
       _$SuiteImpl(
         id:
@@ -145,8 +128,7 @@ class __$$SuiteImplCopyWithImpl<$Res>
 class _$SuiteImpl implements _Suite {
   _$SuiteImpl({required this.id, required this.platform, this.path});
 
-  factory _$SuiteImpl.fromJson(Map<String, dynamic> json) =>
-      _$$SuiteImplFromJson(json);
+  factory _$SuiteImpl.fromJson(Map<String, dynamic> json) => _$$SuiteImplFromJson(json);
 
   /// An opaque ID for this suite.
   @override
@@ -171,8 +153,7 @@ class _$SuiteImpl implements _Suite {
         (other.runtimeType == runtimeType &&
             other is _$SuiteImpl &&
             (identical(other.id, id) || other.id == id) &&
-            (identical(other.platform, platform) ||
-                other.platform == platform) &&
+            (identical(other.platform, platform) || other.platform == platform) &&
             (identical(other.path, path) || other.path == path));
   }
 
@@ -185,8 +166,7 @@ class _$SuiteImpl implements _Suite {
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$SuiteImplCopyWith<_$SuiteImpl> get copyWith =>
-      __$$SuiteImplCopyWithImpl<_$SuiteImpl>(this, _$identity);
+  _$$SuiteImplCopyWith<_$SuiteImpl> get copyWith => __$$SuiteImplCopyWithImpl<_$SuiteImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
@@ -195,11 +175,7 @@ class _$SuiteImpl implements _Suite {
 }
 
 abstract class _Suite implements Suite {
-  factory _Suite({
-    required final int id,
-    required final String platform,
-    final String? path,
-  }) = _$SuiteImpl;
+  factory _Suite({required final int id, required final String platform, final String? path}) = _$SuiteImpl;
 
   factory _Suite.fromJson(Map<String, dynamic> json) = _$SuiteImpl.fromJson;
 
@@ -219,6 +195,5 @@ abstract class _Suite implements Suite {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$SuiteImplCopyWith<_$SuiteImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$SuiteImplCopyWith<_$SuiteImpl> get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/parser/json_reporter_protocol_0_1/suite.freezed.dart
+++ b/lib/src/parser/json_reporter_protocol_0_1/suite.freezed.dart
@@ -1,7 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
-// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
 part of 'suite.dart';
 
@@ -12,7 +12,7 @@ part of 'suite.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods',
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
 );
 
 Suite _$SuiteFromJson(Map<String, dynamic> json) {
@@ -30,79 +30,108 @@ mixin _$Suite {
   /// The path to this suite's file, or `null` if that path is unknown.
   String? get path => throw _privateConstructorUsedError;
 
+  /// Serializes this Suite to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of Suite
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $SuiteCopyWith<Suite> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class $SuiteCopyWith<$Res> {
-  factory $SuiteCopyWith(Suite value, $Res Function(Suite) then) = _$SuiteCopyWithImpl<$Res>;
+  factory $SuiteCopyWith(Suite value, $Res Function(Suite) then) =
+      _$SuiteCopyWithImpl<$Res, Suite>;
+  @useResult
   $Res call({int id, String platform, String? path});
 }
 
 /// @nodoc
-class _$SuiteCopyWithImpl<$Res> implements $SuiteCopyWith<$Res> {
+class _$SuiteCopyWithImpl<$Res, $Val extends Suite>
+    implements $SuiteCopyWith<$Res> {
   _$SuiteCopyWithImpl(this._value, this._then);
 
-  final Suite _value;
   // ignore: unused_field
-  final $Res Function(Suite) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  /// Create a copy of Suite
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
   @override
-  $Res call({Object? id = freezed, Object? platform = freezed, Object? path = freezed}) {
+  $Res call({
+    Object? id = null,
+    Object? platform = null,
+    Object? path = freezed,
+  }) {
     return _then(
       _value.copyWith(
-        id:
-            id == freezed
-                ? _value.id
-                : id // ignore: cast_nullable_to_non_nullable
-                    as int,
-        platform:
-            platform == freezed
-                ? _value.platform
-                : platform // ignore: cast_nullable_to_non_nullable
-                    as String,
-        path:
-            path == freezed
-                ? _value.path
-                : path // ignore: cast_nullable_to_non_nullable
-                    as String?,
-      ),
+            id:
+                null == id
+                    ? _value.id
+                    : id // ignore: cast_nullable_to_non_nullable
+                        as int,
+            platform:
+                null == platform
+                    ? _value.platform
+                    : platform // ignore: cast_nullable_to_non_nullable
+                        as String,
+            path:
+                freezed == path
+                    ? _value.path
+                    : path // ignore: cast_nullable_to_non_nullable
+                        as String?,
+          )
+          as $Val,
     );
   }
 }
 
 /// @nodoc
-abstract class _$$_SuiteCopyWith<$Res> implements $SuiteCopyWith<$Res> {
-  factory _$$_SuiteCopyWith(_$_Suite value, $Res Function(_$_Suite) then) = __$$_SuiteCopyWithImpl<$Res>;
+abstract class _$$SuiteImplCopyWith<$Res> implements $SuiteCopyWith<$Res> {
+  factory _$$SuiteImplCopyWith(
+    _$SuiteImpl value,
+    $Res Function(_$SuiteImpl) then,
+  ) = __$$SuiteImplCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call({int id, String platform, String? path});
 }
 
 /// @nodoc
-class __$$_SuiteCopyWithImpl<$Res> extends _$SuiteCopyWithImpl<$Res> implements _$$_SuiteCopyWith<$Res> {
-  __$$_SuiteCopyWithImpl(_$_Suite _value, $Res Function(_$_Suite) _then) : super(_value, (v) => _then(v as _$_Suite));
+class __$$SuiteImplCopyWithImpl<$Res>
+    extends _$SuiteCopyWithImpl<$Res, _$SuiteImpl>
+    implements _$$SuiteImplCopyWith<$Res> {
+  __$$SuiteImplCopyWithImpl(
+    _$SuiteImpl _value,
+    $Res Function(_$SuiteImpl) _then,
+  ) : super(_value, _then);
 
+  /// Create a copy of Suite
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
   @override
-  _$_Suite get _value => super._value as _$_Suite;
-
-  @override
-  $Res call({Object? id = freezed, Object? platform = freezed, Object? path = freezed}) {
+  $Res call({
+    Object? id = null,
+    Object? platform = null,
+    Object? path = freezed,
+  }) {
     return _then(
-      _$_Suite(
+      _$SuiteImpl(
         id:
-            id == freezed
+            null == id
                 ? _value.id
                 : id // ignore: cast_nullable_to_non_nullable
                     as int,
         platform:
-            platform == freezed
+            null == platform
                 ? _value.platform
                 : platform // ignore: cast_nullable_to_non_nullable
                     as String,
         path:
-            path == freezed
+            freezed == path
                 ? _value.path
                 : path // ignore: cast_nullable_to_non_nullable
                     as String?,
@@ -113,10 +142,11 @@ class __$$_SuiteCopyWithImpl<$Res> extends _$SuiteCopyWithImpl<$Res> implements 
 
 /// @nodoc
 @JsonSerializable()
-class _$_Suite implements _Suite {
-  _$_Suite({required this.id, required this.platform, this.path});
+class _$SuiteImpl implements _Suite {
+  _$SuiteImpl({required this.id, required this.platform, this.path});
 
-  factory _$_Suite.fromJson(Map<String, dynamic> json) => _$$_SuiteFromJson(json);
+  factory _$SuiteImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SuiteImplFromJson(json);
 
   /// An opaque ID for this suite.
   @override
@@ -136,49 +166,59 @@ class _$_Suite implements _Suite {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Suite &&
-            const DeepCollectionEquality().equals(other.id, id) &&
-            const DeepCollectionEquality().equals(other.platform, platform) &&
-            const DeepCollectionEquality().equals(other.path, path));
+            other is _$SuiteImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.platform, platform) ||
+                other.platform == platform) &&
+            (identical(other.path, path) || other.path == path));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(
-    runtimeType,
-    const DeepCollectionEquality().hash(id),
-    const DeepCollectionEquality().hash(platform),
-    const DeepCollectionEquality().hash(path),
-  );
+  int get hashCode => Object.hash(runtimeType, id, platform, path);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Suite
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  _$$_SuiteCopyWith<_$_Suite> get copyWith => __$$_SuiteCopyWithImpl<_$_Suite>(this, _$identity);
+  @pragma('vm:prefer-inline')
+  _$$SuiteImplCopyWith<_$SuiteImpl> get copyWith =>
+      __$$SuiteImplCopyWithImpl<_$SuiteImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_SuiteToJson(this);
+    return _$$SuiteImplToJson(this);
   }
 }
 
 abstract class _Suite implements Suite {
-  factory _Suite({required final int id, required final String platform, final String? path}) = _$_Suite;
+  factory _Suite({
+    required final int id,
+    required final String platform,
+    final String? path,
+  }) = _$SuiteImpl;
 
-  factory _Suite.fromJson(Map<String, dynamic> json) = _$_Suite.fromJson;
+  factory _Suite.fromJson(Map<String, dynamic> json) = _$SuiteImpl.fromJson;
 
-  @override
   /// An opaque ID for this suite.
+  @override
   int get id;
-  @override
+
   /// The platform on which this suite is running.
+  @override
   String get platform;
-  @override
+
   /// The path to this suite's file, or `null` if that path is unknown.
-  String? get path;
   @override
-  @JsonKey(ignore: true)
-  _$$_SuiteCopyWith<_$_Suite> get copyWith => throw _privateConstructorUsedError;
+  String? get path;
+
+  /// Create a copy of Suite
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$SuiteImplCopyWith<_$SuiteImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }

--- a/lib/src/parser/json_reporter_protocol_0_1/suite.g.dart
+++ b/lib/src/parser/json_reporter_protocol_0_1/suite.g.dart
@@ -8,19 +8,17 @@ part of 'suite.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$SuiteImpl _$$SuiteImplFromJson(Map<String, dynamic> json) =>
-    $checkedCreate(r'_$SuiteImpl', json, ($checkedConvert) {
-      final val = _$SuiteImpl(
-        id: $checkedConvert('id', (v) => (v as num).toInt()),
-        platform: $checkedConvert('platform', (v) => v as String),
-        path: $checkedConvert('path', (v) => v as String?),
-      );
-      return val;
-    });
+_$SuiteImpl _$$SuiteImplFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$SuiteImpl', json, ($checkedConvert) {
+  final val = _$SuiteImpl(
+    id: $checkedConvert('id', (v) => (v as num).toInt()),
+    platform: $checkedConvert('platform', (v) => v as String),
+    path: $checkedConvert('path', (v) => v as String?),
+  );
+  return val;
+});
 
-Map<String, dynamic> _$$SuiteImplToJson(_$SuiteImpl instance) =>
-    <String, dynamic>{
-      'id': instance.id,
-      'platform': instance.platform,
-      'path': instance.path,
-    };
+Map<String, dynamic> _$$SuiteImplToJson(_$SuiteImpl instance) => <String, dynamic>{
+  'id': instance.id,
+  'platform': instance.platform,
+  'path': instance.path,
+};

--- a/lib/src/parser/json_reporter_protocol_0_1/suite.g.dart
+++ b/lib/src/parser/json_reporter_protocol_0_1/suite.g.dart
@@ -8,21 +8,17 @@ part of 'suite.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_Suite _$$_SuiteFromJson(Map<String, dynamic> json) => $checkedCreate(
-      r'_$_Suite',
-      json,
-      ($checkedConvert) {
-        final val = _$_Suite(
-          id: $checkedConvert('id', (v) => v as int),
-          platform: $checkedConvert('platform', (v) => v as String),
-          path: $checkedConvert('path', (v) => v as String?),
-        );
-        return val;
-      },
-    );
+_$_Suite _$$_SuiteFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$_Suite', json, ($checkedConvert) {
+  final val = _$_Suite(
+    id: $checkedConvert('id', (v) => v as int),
+    platform: $checkedConvert('platform', (v) => v as String),
+    path: $checkedConvert('path', (v) => v as String?),
+  );
+  return val;
+});
 
 Map<String, dynamic> _$$_SuiteToJson(_$_Suite instance) => <String, dynamic>{
-      'id': instance.id,
-      'platform': instance.platform,
-      'path': instance.path,
-    };
+  'id': instance.id,
+  'platform': instance.platform,
+  'path': instance.path,
+};

--- a/lib/src/parser/json_reporter_protocol_0_1/suite.g.dart
+++ b/lib/src/parser/json_reporter_protocol_0_1/suite.g.dart
@@ -8,17 +8,19 @@ part of 'suite.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$SuiteImpl _$$SuiteImplFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$SuiteImpl', json, ($checkedConvert) {
-  final val = _$SuiteImpl(
-    id: $checkedConvert('id', (v) => (v as num).toInt()),
-    platform: $checkedConvert('platform', (v) => v as String),
-    path: $checkedConvert('path', (v) => v as String?),
-  );
-  return val;
-});
+_$SuiteImpl _$$SuiteImplFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(r'_$SuiteImpl', json, ($checkedConvert) {
+      final val = _$SuiteImpl(
+        id: $checkedConvert('id', (v) => (v as num).toInt()),
+        platform: $checkedConvert('platform', (v) => v as String),
+        path: $checkedConvert('path', (v) => v as String?),
+      );
+      return val;
+    });
 
-Map<String, dynamic> _$$SuiteImplToJson(_$SuiteImpl instance) => <String, dynamic>{
-  'id': instance.id,
-  'platform': instance.platform,
-  'path': instance.path,
-};
+Map<String, dynamic> _$$SuiteImplToJson(_$SuiteImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'platform': instance.platform,
+      'path': instance.path,
+    };

--- a/lib/src/parser/json_reporter_protocol_0_1/suite.g.dart
+++ b/lib/src/parser/json_reporter_protocol_0_1/suite.g.dart
@@ -8,17 +8,19 @@ part of 'suite.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_Suite _$$_SuiteFromJson(Map<String, dynamic> json) => $checkedCreate(r'_$_Suite', json, ($checkedConvert) {
-  final val = _$_Suite(
-    id: $checkedConvert('id', (v) => v as int),
-    platform: $checkedConvert('platform', (v) => v as String),
-    path: $checkedConvert('path', (v) => v as String?),
-  );
-  return val;
-});
+_$SuiteImpl _$$SuiteImplFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(r'_$SuiteImpl', json, ($checkedConvert) {
+      final val = _$SuiteImpl(
+        id: $checkedConvert('id', (v) => (v as num).toInt()),
+        platform: $checkedConvert('platform', (v) => v as String),
+        path: $checkedConvert('path', (v) => v as String?),
+      );
+      return val;
+    });
 
-Map<String, dynamic> _$$_SuiteToJson(_$_Suite instance) => <String, dynamic>{
-  'id': instance.id,
-  'platform': instance.platform,
-  'path': instance.path,
-};
+Map<String, dynamic> _$$SuiteImplToJson(_$SuiteImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'platform': instance.platform,
+      'path': instance.path,
+    };

--- a/lib/src/parser/json_reporter_protocol_0_1/test.freezed.dart
+++ b/lib/src/parser/json_reporter_protocol_0_1/test.freezed.dart
@@ -12,7 +12,8 @@ part of 'test.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods',
+);
 
 Test _$TestFromJson(Map<String, dynamic> json) {
   return _Test.fromJson(json);
@@ -68,19 +69,19 @@ mixin _$Test {
 
 /// @nodoc
 abstract class $TestCopyWith<$Res> {
-  factory $TestCopyWith(Test value, $Res Function(Test) then) =
-      _$TestCopyWithImpl<$Res>;
-  $Res call(
-      {int id,
-      String name,
-      @JsonKey(name: 'suiteID') int suiteId,
-      @JsonKey(name: 'groupIDs') List<int> groupIds,
-      int? line,
-      int? column,
-      String? url,
-      @JsonKey(name: 'root_line') int? rootLine,
-      @JsonKey(name: 'root_column') int? rootColumn,
-      @JsonKey(name: 'root_url') String? rootUrl});
+  factory $TestCopyWith(Test value, $Res Function(Test) then) = _$TestCopyWithImpl<$Res>;
+  $Res call({
+    int id,
+    String name,
+    @JsonKey(name: 'suiteID') int suiteId,
+    @JsonKey(name: 'groupIDs') List<int> groupIds,
+    int? line,
+    int? column,
+    String? url,
+    @JsonKey(name: 'root_line') int? rootLine,
+    @JsonKey(name: 'root_column') int? rootColumn,
+    @JsonKey(name: 'root_url') String? rootUrl,
+  });
 }
 
 /// @nodoc
@@ -104,74 +105,84 @@ class _$TestCopyWithImpl<$Res> implements $TestCopyWith<$Res> {
     Object? rootColumn = freezed,
     Object? rootUrl = freezed,
   }) {
-    return _then(_value.copyWith(
-      id: id == freezed
-          ? _value.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as int,
-      name: name == freezed
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      suiteId: suiteId == freezed
-          ? _value.suiteId
-          : suiteId // ignore: cast_nullable_to_non_nullable
-              as int,
-      groupIds: groupIds == freezed
-          ? _value.groupIds
-          : groupIds // ignore: cast_nullable_to_non_nullable
-              as List<int>,
-      line: line == freezed
-          ? _value.line
-          : line // ignore: cast_nullable_to_non_nullable
-              as int?,
-      column: column == freezed
-          ? _value.column
-          : column // ignore: cast_nullable_to_non_nullable
-              as int?,
-      url: url == freezed
-          ? _value.url
-          : url // ignore: cast_nullable_to_non_nullable
-              as String?,
-      rootLine: rootLine == freezed
-          ? _value.rootLine
-          : rootLine // ignore: cast_nullable_to_non_nullable
-              as int?,
-      rootColumn: rootColumn == freezed
-          ? _value.rootColumn
-          : rootColumn // ignore: cast_nullable_to_non_nullable
-              as int?,
-      rootUrl: rootUrl == freezed
-          ? _value.rootUrl
-          : rootUrl // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
+    return _then(
+      _value.copyWith(
+        id:
+            id == freezed
+                ? _value.id
+                : id // ignore: cast_nullable_to_non_nullable
+                    as int,
+        name:
+            name == freezed
+                ? _value.name
+                : name // ignore: cast_nullable_to_non_nullable
+                    as String,
+        suiteId:
+            suiteId == freezed
+                ? _value.suiteId
+                : suiteId // ignore: cast_nullable_to_non_nullable
+                    as int,
+        groupIds:
+            groupIds == freezed
+                ? _value.groupIds
+                : groupIds // ignore: cast_nullable_to_non_nullable
+                    as List<int>,
+        line:
+            line == freezed
+                ? _value.line
+                : line // ignore: cast_nullable_to_non_nullable
+                    as int?,
+        column:
+            column == freezed
+                ? _value.column
+                : column // ignore: cast_nullable_to_non_nullable
+                    as int?,
+        url:
+            url == freezed
+                ? _value.url
+                : url // ignore: cast_nullable_to_non_nullable
+                    as String?,
+        rootLine:
+            rootLine == freezed
+                ? _value.rootLine
+                : rootLine // ignore: cast_nullable_to_non_nullable
+                    as int?,
+        rootColumn:
+            rootColumn == freezed
+                ? _value.rootColumn
+                : rootColumn // ignore: cast_nullable_to_non_nullable
+                    as int?,
+        rootUrl:
+            rootUrl == freezed
+                ? _value.rootUrl
+                : rootUrl // ignore: cast_nullable_to_non_nullable
+                    as String?,
+      ),
+    );
   }
 }
 
 /// @nodoc
 abstract class _$$_TestCopyWith<$Res> implements $TestCopyWith<$Res> {
-  factory _$$_TestCopyWith(_$_Test value, $Res Function(_$_Test) then) =
-      __$$_TestCopyWithImpl<$Res>;
+  factory _$$_TestCopyWith(_$_Test value, $Res Function(_$_Test) then) = __$$_TestCopyWithImpl<$Res>;
   @override
-  $Res call(
-      {int id,
-      String name,
-      @JsonKey(name: 'suiteID') int suiteId,
-      @JsonKey(name: 'groupIDs') List<int> groupIds,
-      int? line,
-      int? column,
-      String? url,
-      @JsonKey(name: 'root_line') int? rootLine,
-      @JsonKey(name: 'root_column') int? rootColumn,
-      @JsonKey(name: 'root_url') String? rootUrl});
+  $Res call({
+    int id,
+    String name,
+    @JsonKey(name: 'suiteID') int suiteId,
+    @JsonKey(name: 'groupIDs') List<int> groupIds,
+    int? line,
+    int? column,
+    String? url,
+    @JsonKey(name: 'root_line') int? rootLine,
+    @JsonKey(name: 'root_column') int? rootColumn,
+    @JsonKey(name: 'root_url') String? rootUrl,
+  });
 }
 
 /// @nodoc
-class __$$_TestCopyWithImpl<$Res> extends _$TestCopyWithImpl<$Res>
-    implements _$$_TestCopyWith<$Res> {
-  __$$_TestCopyWithImpl(_$_Test _value, $Res Function(_$_Test) _then)
-      : super(_value, (v) => _then(v as _$_Test));
+class __$$_TestCopyWithImpl<$Res> extends _$TestCopyWithImpl<$Res> implements _$$_TestCopyWith<$Res> {
+  __$$_TestCopyWithImpl(_$_Test _value, $Res Function(_$_Test) _then) : super(_value, (v) => _then(v as _$_Test));
 
   @override
   _$_Test get _value => super._value as _$_Test;
@@ -189,66 +200,78 @@ class __$$_TestCopyWithImpl<$Res> extends _$TestCopyWithImpl<$Res>
     Object? rootColumn = freezed,
     Object? rootUrl = freezed,
   }) {
-    return _then(_$_Test(
-      id: id == freezed
-          ? _value.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as int,
-      name: name == freezed
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      suiteId: suiteId == freezed
-          ? _value.suiteId
-          : suiteId // ignore: cast_nullable_to_non_nullable
-              as int,
-      groupIds: groupIds == freezed
-          ? _value._groupIds
-          : groupIds // ignore: cast_nullable_to_non_nullable
-              as List<int>,
-      line: line == freezed
-          ? _value.line
-          : line // ignore: cast_nullable_to_non_nullable
-              as int?,
-      column: column == freezed
-          ? _value.column
-          : column // ignore: cast_nullable_to_non_nullable
-              as int?,
-      url: url == freezed
-          ? _value.url
-          : url // ignore: cast_nullable_to_non_nullable
-              as String?,
-      rootLine: rootLine == freezed
-          ? _value.rootLine
-          : rootLine // ignore: cast_nullable_to_non_nullable
-              as int?,
-      rootColumn: rootColumn == freezed
-          ? _value.rootColumn
-          : rootColumn // ignore: cast_nullable_to_non_nullable
-              as int?,
-      rootUrl: rootUrl == freezed
-          ? _value.rootUrl
-          : rootUrl // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
+    return _then(
+      _$_Test(
+        id:
+            id == freezed
+                ? _value.id
+                : id // ignore: cast_nullable_to_non_nullable
+                    as int,
+        name:
+            name == freezed
+                ? _value.name
+                : name // ignore: cast_nullable_to_non_nullable
+                    as String,
+        suiteId:
+            suiteId == freezed
+                ? _value.suiteId
+                : suiteId // ignore: cast_nullable_to_non_nullable
+                    as int,
+        groupIds:
+            groupIds == freezed
+                ? _value._groupIds
+                : groupIds // ignore: cast_nullable_to_non_nullable
+                    as List<int>,
+        line:
+            line == freezed
+                ? _value.line
+                : line // ignore: cast_nullable_to_non_nullable
+                    as int?,
+        column:
+            column == freezed
+                ? _value.column
+                : column // ignore: cast_nullable_to_non_nullable
+                    as int?,
+        url:
+            url == freezed
+                ? _value.url
+                : url // ignore: cast_nullable_to_non_nullable
+                    as String?,
+        rootLine:
+            rootLine == freezed
+                ? _value.rootLine
+                : rootLine // ignore: cast_nullable_to_non_nullable
+                    as int?,
+        rootColumn:
+            rootColumn == freezed
+                ? _value.rootColumn
+                : rootColumn // ignore: cast_nullable_to_non_nullable
+                    as int?,
+        rootUrl:
+            rootUrl == freezed
+                ? _value.rootUrl
+                : rootUrl // ignore: cast_nullable_to_non_nullable
+                    as String?,
+      ),
+    );
   }
 }
 
 /// @nodoc
 @JsonSerializable()
 class _$_Test implements _Test {
-  _$_Test(
-      {required this.id,
-      required this.name,
-      @JsonKey(name: 'suiteID') required this.suiteId,
-      @JsonKey(name: 'groupIDs') required final List<int> groupIds,
-      this.line,
-      this.column,
-      this.url,
-      @JsonKey(name: 'root_line') this.rootLine,
-      @JsonKey(name: 'root_column') this.rootColumn,
-      @JsonKey(name: 'root_url') this.rootUrl})
-      : _groupIds = groupIds;
+  _$_Test({
+    required this.id,
+    required this.name,
+    @JsonKey(name: 'suiteID') required this.suiteId,
+    @JsonKey(name: 'groupIDs') required final List<int> groupIds,
+    this.line,
+    this.column,
+    this.url,
+    @JsonKey(name: 'root_line') this.rootLine,
+    @JsonKey(name: 'root_column') this.rootColumn,
+    @JsonKey(name: 'root_url') this.rootUrl,
+  }) : _groupIds = groupIds;
 
   factory _$_Test.fromJson(Map<String, dynamic> json) => _$$_TestFromJson(json);
 
@@ -327,100 +350,88 @@ class _$_Test implements _Test {
             const DeepCollectionEquality().equals(other.column, column) &&
             const DeepCollectionEquality().equals(other.url, url) &&
             const DeepCollectionEquality().equals(other.rootLine, rootLine) &&
-            const DeepCollectionEquality()
-                .equals(other.rootColumn, rootColumn) &&
+            const DeepCollectionEquality().equals(other.rootColumn, rootColumn) &&
             const DeepCollectionEquality().equals(other.rootUrl, rootUrl));
   }
 
   @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(id),
-      const DeepCollectionEquality().hash(name),
-      const DeepCollectionEquality().hash(suiteId),
-      const DeepCollectionEquality().hash(_groupIds),
-      const DeepCollectionEquality().hash(line),
-      const DeepCollectionEquality().hash(column),
-      const DeepCollectionEquality().hash(url),
-      const DeepCollectionEquality().hash(rootLine),
-      const DeepCollectionEquality().hash(rootColumn),
-      const DeepCollectionEquality().hash(rootUrl));
+    runtimeType,
+    const DeepCollectionEquality().hash(id),
+    const DeepCollectionEquality().hash(name),
+    const DeepCollectionEquality().hash(suiteId),
+    const DeepCollectionEquality().hash(_groupIds),
+    const DeepCollectionEquality().hash(line),
+    const DeepCollectionEquality().hash(column),
+    const DeepCollectionEquality().hash(url),
+    const DeepCollectionEquality().hash(rootLine),
+    const DeepCollectionEquality().hash(rootColumn),
+    const DeepCollectionEquality().hash(rootUrl),
+  );
 
   @JsonKey(ignore: true)
   @override
-  _$$_TestCopyWith<_$_Test> get copyWith =>
-      __$$_TestCopyWithImpl<_$_Test>(this, _$identity);
+  _$$_TestCopyWith<_$_Test> get copyWith => __$$_TestCopyWithImpl<_$_Test>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_TestToJson(
-      this,
-    );
+    return _$$_TestToJson(this);
   }
 }
 
 abstract class _Test implements Test {
-  factory _Test(
-      {required final int id,
-      required final String name,
-      @JsonKey(name: 'suiteID') required final int suiteId,
-      @JsonKey(name: 'groupIDs') required final List<int> groupIds,
-      final int? line,
-      final int? column,
-      final String? url,
-      @JsonKey(name: 'root_line') final int? rootLine,
-      @JsonKey(name: 'root_column') final int? rootColumn,
-      @JsonKey(name: 'root_url') final String? rootUrl}) = _$_Test;
+  factory _Test({
+    required final int id,
+    required final String name,
+    @JsonKey(name: 'suiteID') required final int suiteId,
+    @JsonKey(name: 'groupIDs') required final List<int> groupIds,
+    final int? line,
+    final int? column,
+    final String? url,
+    @JsonKey(name: 'root_line') final int? rootLine,
+    @JsonKey(name: 'root_column') final int? rootColumn,
+    @JsonKey(name: 'root_url') final String? rootUrl,
+  }) = _$_Test;
 
   factory _Test.fromJson(Map<String, dynamic> json) = _$_Test.fromJson;
 
   @override
-
   /// An opaque ID for this test.
   int get id;
   @override
-
   /// The name of this test, including prefixes from any containing groups.
   String get name;
   @override
-
   /// The ID of the suite containing this test.
   @JsonKey(name: 'suiteID')
   int get suiteId;
   @override
-
   /// The IDs of groups containing this test, in order from outermost to innermost.
   @JsonKey(name: 'groupIDs')
   List<int> get groupIds;
   @override
-
   /// The (1-based) line on which this test was defined, or `null`.
   int? get line;
   @override
-
   /// The (1-based) column on which this test was defined, or `null`.
   int? get column;
   @override
-
   /// The URL for the file in which this test was defined, or `null`.
   String? get url;
   @override
-
   /// The (1-based) line in the original test suite from which this test originated.
   ///
   /// Will only be present if `rootUrl` is different from `url`.
   @JsonKey(name: 'root_line')
   int? get rootLine;
   @override
-
   /// The (1-based) line on in the original test suite from which this test originated.
   ///
   /// Will only be present if `rootUrl` is different from `url`.
   @JsonKey(name: 'root_column')
   int? get rootColumn;
   @override
-
   /// The URL for the original test suite in which this test was defined.
   ///
   /// Will only be present if different from `url`.

--- a/lib/src/parser/json_reporter_protocol_0_1/test.freezed.dart
+++ b/lib/src/parser/json_reporter_protocol_0_1/test.freezed.dart
@@ -73,7 +73,8 @@ mixin _$Test {
 
 /// @nodoc
 abstract class $TestCopyWith<$Res> {
-  factory $TestCopyWith(Test value, $Res Function(Test) then) = _$TestCopyWithImpl<$Res, Test>;
+  factory $TestCopyWith(Test value, $Res Function(Test) then) =
+      _$TestCopyWithImpl<$Res, Test>;
   @useResult
   $Res call({
     int id,
@@ -90,7 +91,8 @@ abstract class $TestCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$TestCopyWithImpl<$Res, $Val extends Test> implements $TestCopyWith<$Res> {
+class _$TestCopyWithImpl<$Res, $Val extends Test>
+    implements $TestCopyWith<$Res> {
   _$TestCopyWithImpl(this._value, this._then);
 
   // ignore: unused_field
@@ -174,7 +176,10 @@ class _$TestCopyWithImpl<$Res, $Val extends Test> implements $TestCopyWith<$Res>
 
 /// @nodoc
 abstract class _$$TestImplCopyWith<$Res> implements $TestCopyWith<$Res> {
-  factory _$$TestImplCopyWith(_$TestImpl value, $Res Function(_$TestImpl) then) = __$$TestImplCopyWithImpl<$Res>;
+  factory _$$TestImplCopyWith(
+    _$TestImpl value,
+    $Res Function(_$TestImpl) then,
+  ) = __$$TestImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({
@@ -192,8 +197,11 @@ abstract class _$$TestImplCopyWith<$Res> implements $TestCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$TestImplCopyWithImpl<$Res> extends _$TestCopyWithImpl<$Res, _$TestImpl> implements _$$TestImplCopyWith<$Res> {
-  __$$TestImplCopyWithImpl(_$TestImpl _value, $Res Function(_$TestImpl) _then) : super(_value, _then);
+class __$$TestImplCopyWithImpl<$Res>
+    extends _$TestCopyWithImpl<$Res, _$TestImpl>
+    implements _$$TestImplCopyWith<$Res> {
+  __$$TestImplCopyWithImpl(_$TestImpl _value, $Res Function(_$TestImpl) _then)
+    : super(_value, _then);
 
   /// Create a copy of Test
   /// with the given fields replaced by the non-null parameter values.
@@ -284,7 +292,8 @@ class _$TestImpl implements _Test {
     @JsonKey(name: 'root_url') this.rootUrl,
   }) : _groupIds = groupIds;
 
-  factory _$TestImpl.fromJson(Map<String, dynamic> json) => _$$TestImplFromJson(json);
+  factory _$TestImpl.fromJson(Map<String, dynamic> json) =>
+      _$$TestImplFromJson(json);
 
   /// An opaque ID for this test.
   @override
@@ -361,8 +370,10 @@ class _$TestImpl implements _Test {
             (identical(other.line, line) || other.line == line) &&
             (identical(other.column, column) || other.column == column) &&
             (identical(other.url, url) || other.url == url) &&
-            (identical(other.rootLine, rootLine) || other.rootLine == rootLine) &&
-            (identical(other.rootColumn, rootColumn) || other.rootColumn == rootColumn) &&
+            (identical(other.rootLine, rootLine) ||
+                other.rootLine == rootLine) &&
+            (identical(other.rootColumn, rootColumn) ||
+                other.rootColumn == rootColumn) &&
             (identical(other.rootUrl, rootUrl) || other.rootUrl == rootUrl));
   }
 
@@ -387,7 +398,8 @@ class _$TestImpl implements _Test {
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$TestImplCopyWith<_$TestImpl> get copyWith => __$$TestImplCopyWithImpl<_$TestImpl>(this, _$identity);
+  _$$TestImplCopyWith<_$TestImpl> get copyWith =>
+      __$$TestImplCopyWithImpl<_$TestImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
@@ -466,5 +478,6 @@ abstract class _Test implements Test {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$TestImplCopyWith<_$TestImpl> get copyWith => throw _privateConstructorUsedError;
+  _$$TestImplCopyWith<_$TestImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }

--- a/lib/src/parser/json_reporter_protocol_0_1/test.freezed.dart
+++ b/lib/src/parser/json_reporter_protocol_0_1/test.freezed.dart
@@ -73,8 +73,7 @@ mixin _$Test {
 
 /// @nodoc
 abstract class $TestCopyWith<$Res> {
-  factory $TestCopyWith(Test value, $Res Function(Test) then) =
-      _$TestCopyWithImpl<$Res, Test>;
+  factory $TestCopyWith(Test value, $Res Function(Test) then) = _$TestCopyWithImpl<$Res, Test>;
   @useResult
   $Res call({
     int id,
@@ -91,8 +90,7 @@ abstract class $TestCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$TestCopyWithImpl<$Res, $Val extends Test>
-    implements $TestCopyWith<$Res> {
+class _$TestCopyWithImpl<$Res, $Val extends Test> implements $TestCopyWith<$Res> {
   _$TestCopyWithImpl(this._value, this._then);
 
   // ignore: unused_field
@@ -176,10 +174,7 @@ class _$TestCopyWithImpl<$Res, $Val extends Test>
 
 /// @nodoc
 abstract class _$$TestImplCopyWith<$Res> implements $TestCopyWith<$Res> {
-  factory _$$TestImplCopyWith(
-    _$TestImpl value,
-    $Res Function(_$TestImpl) then,
-  ) = __$$TestImplCopyWithImpl<$Res>;
+  factory _$$TestImplCopyWith(_$TestImpl value, $Res Function(_$TestImpl) then) = __$$TestImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({
@@ -197,11 +192,8 @@ abstract class _$$TestImplCopyWith<$Res> implements $TestCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$TestImplCopyWithImpl<$Res>
-    extends _$TestCopyWithImpl<$Res, _$TestImpl>
-    implements _$$TestImplCopyWith<$Res> {
-  __$$TestImplCopyWithImpl(_$TestImpl _value, $Res Function(_$TestImpl) _then)
-    : super(_value, _then);
+class __$$TestImplCopyWithImpl<$Res> extends _$TestCopyWithImpl<$Res, _$TestImpl> implements _$$TestImplCopyWith<$Res> {
+  __$$TestImplCopyWithImpl(_$TestImpl _value, $Res Function(_$TestImpl) _then) : super(_value, _then);
 
   /// Create a copy of Test
   /// with the given fields replaced by the non-null parameter values.
@@ -292,8 +284,7 @@ class _$TestImpl implements _Test {
     @JsonKey(name: 'root_url') this.rootUrl,
   }) : _groupIds = groupIds;
 
-  factory _$TestImpl.fromJson(Map<String, dynamic> json) =>
-      _$$TestImplFromJson(json);
+  factory _$TestImpl.fromJson(Map<String, dynamic> json) => _$$TestImplFromJson(json);
 
   /// An opaque ID for this test.
   @override
@@ -370,10 +361,8 @@ class _$TestImpl implements _Test {
             (identical(other.line, line) || other.line == line) &&
             (identical(other.column, column) || other.column == column) &&
             (identical(other.url, url) || other.url == url) &&
-            (identical(other.rootLine, rootLine) ||
-                other.rootLine == rootLine) &&
-            (identical(other.rootColumn, rootColumn) ||
-                other.rootColumn == rootColumn) &&
+            (identical(other.rootLine, rootLine) || other.rootLine == rootLine) &&
+            (identical(other.rootColumn, rootColumn) || other.rootColumn == rootColumn) &&
             (identical(other.rootUrl, rootUrl) || other.rootUrl == rootUrl));
   }
 
@@ -398,8 +387,7 @@ class _$TestImpl implements _Test {
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$TestImplCopyWith<_$TestImpl> get copyWith =>
-      __$$TestImplCopyWithImpl<_$TestImpl>(this, _$identity);
+  _$$TestImplCopyWith<_$TestImpl> get copyWith => __$$TestImplCopyWithImpl<_$TestImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
@@ -478,6 +466,5 @@ abstract class _Test implements Test {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$TestImplCopyWith<_$TestImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$TestImplCopyWith<_$TestImpl> get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/parser/json_reporter_protocol_0_1/test.freezed.dart
+++ b/lib/src/parser/json_reporter_protocol_0_1/test.freezed.dart
@@ -1,7 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
-// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
 part of 'test.dart';
 
@@ -12,7 +12,7 @@ part of 'test.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods',
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
 );
 
 Test _$TestFromJson(Map<String, dynamic> json) {
@@ -62,14 +62,20 @@ mixin _$Test {
   @JsonKey(name: 'root_url')
   String? get rootUrl => throw _privateConstructorUsedError;
 
+  /// Serializes this Test to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of Test
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $TestCopyWith<Test> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class $TestCopyWith<$Res> {
-  factory $TestCopyWith(Test value, $Res Function(Test) then) = _$TestCopyWithImpl<$Res>;
+  factory $TestCopyWith(Test value, $Res Function(Test) then) =
+      _$TestCopyWithImpl<$Res, Test>;
+  @useResult
   $Res call({
     int id,
     String name,
@@ -85,19 +91,24 @@ abstract class $TestCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$TestCopyWithImpl<$Res> implements $TestCopyWith<$Res> {
+class _$TestCopyWithImpl<$Res, $Val extends Test>
+    implements $TestCopyWith<$Res> {
   _$TestCopyWithImpl(this._value, this._then);
 
-  final Test _value;
   // ignore: unused_field
-  final $Res Function(Test) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  /// Create a copy of Test
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? id = freezed,
-    Object? name = freezed,
-    Object? suiteId = freezed,
-    Object? groupIds = freezed,
+    Object? id = null,
+    Object? name = null,
+    Object? suiteId = null,
+    Object? groupIds = null,
     Object? line = freezed,
     Object? column = freezed,
     Object? url = freezed,
@@ -107,65 +118,70 @@ class _$TestCopyWithImpl<$Res> implements $TestCopyWith<$Res> {
   }) {
     return _then(
       _value.copyWith(
-        id:
-            id == freezed
-                ? _value.id
-                : id // ignore: cast_nullable_to_non_nullable
-                    as int,
-        name:
-            name == freezed
-                ? _value.name
-                : name // ignore: cast_nullable_to_non_nullable
-                    as String,
-        suiteId:
-            suiteId == freezed
-                ? _value.suiteId
-                : suiteId // ignore: cast_nullable_to_non_nullable
-                    as int,
-        groupIds:
-            groupIds == freezed
-                ? _value.groupIds
-                : groupIds // ignore: cast_nullable_to_non_nullable
-                    as List<int>,
-        line:
-            line == freezed
-                ? _value.line
-                : line // ignore: cast_nullable_to_non_nullable
-                    as int?,
-        column:
-            column == freezed
-                ? _value.column
-                : column // ignore: cast_nullable_to_non_nullable
-                    as int?,
-        url:
-            url == freezed
-                ? _value.url
-                : url // ignore: cast_nullable_to_non_nullable
-                    as String?,
-        rootLine:
-            rootLine == freezed
-                ? _value.rootLine
-                : rootLine // ignore: cast_nullable_to_non_nullable
-                    as int?,
-        rootColumn:
-            rootColumn == freezed
-                ? _value.rootColumn
-                : rootColumn // ignore: cast_nullable_to_non_nullable
-                    as int?,
-        rootUrl:
-            rootUrl == freezed
-                ? _value.rootUrl
-                : rootUrl // ignore: cast_nullable_to_non_nullable
-                    as String?,
-      ),
+            id:
+                null == id
+                    ? _value.id
+                    : id // ignore: cast_nullable_to_non_nullable
+                        as int,
+            name:
+                null == name
+                    ? _value.name
+                    : name // ignore: cast_nullable_to_non_nullable
+                        as String,
+            suiteId:
+                null == suiteId
+                    ? _value.suiteId
+                    : suiteId // ignore: cast_nullable_to_non_nullable
+                        as int,
+            groupIds:
+                null == groupIds
+                    ? _value.groupIds
+                    : groupIds // ignore: cast_nullable_to_non_nullable
+                        as List<int>,
+            line:
+                freezed == line
+                    ? _value.line
+                    : line // ignore: cast_nullable_to_non_nullable
+                        as int?,
+            column:
+                freezed == column
+                    ? _value.column
+                    : column // ignore: cast_nullable_to_non_nullable
+                        as int?,
+            url:
+                freezed == url
+                    ? _value.url
+                    : url // ignore: cast_nullable_to_non_nullable
+                        as String?,
+            rootLine:
+                freezed == rootLine
+                    ? _value.rootLine
+                    : rootLine // ignore: cast_nullable_to_non_nullable
+                        as int?,
+            rootColumn:
+                freezed == rootColumn
+                    ? _value.rootColumn
+                    : rootColumn // ignore: cast_nullable_to_non_nullable
+                        as int?,
+            rootUrl:
+                freezed == rootUrl
+                    ? _value.rootUrl
+                    : rootUrl // ignore: cast_nullable_to_non_nullable
+                        as String?,
+          )
+          as $Val,
     );
   }
 }
 
 /// @nodoc
-abstract class _$$_TestCopyWith<$Res> implements $TestCopyWith<$Res> {
-  factory _$$_TestCopyWith(_$_Test value, $Res Function(_$_Test) then) = __$$_TestCopyWithImpl<$Res>;
+abstract class _$$TestImplCopyWith<$Res> implements $TestCopyWith<$Res> {
+  factory _$$TestImplCopyWith(
+    _$TestImpl value,
+    $Res Function(_$TestImpl) then,
+  ) = __$$TestImplCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call({
     int id,
     String name,
@@ -181,18 +197,21 @@ abstract class _$$_TestCopyWith<$Res> implements $TestCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_TestCopyWithImpl<$Res> extends _$TestCopyWithImpl<$Res> implements _$$_TestCopyWith<$Res> {
-  __$$_TestCopyWithImpl(_$_Test _value, $Res Function(_$_Test) _then) : super(_value, (v) => _then(v as _$_Test));
+class __$$TestImplCopyWithImpl<$Res>
+    extends _$TestCopyWithImpl<$Res, _$TestImpl>
+    implements _$$TestImplCopyWith<$Res> {
+  __$$TestImplCopyWithImpl(_$TestImpl _value, $Res Function(_$TestImpl) _then)
+    : super(_value, _then);
 
-  @override
-  _$_Test get _value => super._value as _$_Test;
-
+  /// Create a copy of Test
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? id = freezed,
-    Object? name = freezed,
-    Object? suiteId = freezed,
-    Object? groupIds = freezed,
+    Object? id = null,
+    Object? name = null,
+    Object? suiteId = null,
+    Object? groupIds = null,
     Object? line = freezed,
     Object? column = freezed,
     Object? url = freezed,
@@ -201,54 +220,54 @@ class __$$_TestCopyWithImpl<$Res> extends _$TestCopyWithImpl<$Res> implements _$
     Object? rootUrl = freezed,
   }) {
     return _then(
-      _$_Test(
+      _$TestImpl(
         id:
-            id == freezed
+            null == id
                 ? _value.id
                 : id // ignore: cast_nullable_to_non_nullable
                     as int,
         name:
-            name == freezed
+            null == name
                 ? _value.name
                 : name // ignore: cast_nullable_to_non_nullable
                     as String,
         suiteId:
-            suiteId == freezed
+            null == suiteId
                 ? _value.suiteId
                 : suiteId // ignore: cast_nullable_to_non_nullable
                     as int,
         groupIds:
-            groupIds == freezed
+            null == groupIds
                 ? _value._groupIds
                 : groupIds // ignore: cast_nullable_to_non_nullable
                     as List<int>,
         line:
-            line == freezed
+            freezed == line
                 ? _value.line
                 : line // ignore: cast_nullable_to_non_nullable
                     as int?,
         column:
-            column == freezed
+            freezed == column
                 ? _value.column
                 : column // ignore: cast_nullable_to_non_nullable
                     as int?,
         url:
-            url == freezed
+            freezed == url
                 ? _value.url
                 : url // ignore: cast_nullable_to_non_nullable
                     as String?,
         rootLine:
-            rootLine == freezed
+            freezed == rootLine
                 ? _value.rootLine
                 : rootLine // ignore: cast_nullable_to_non_nullable
                     as int?,
         rootColumn:
-            rootColumn == freezed
+            freezed == rootColumn
                 ? _value.rootColumn
                 : rootColumn // ignore: cast_nullable_to_non_nullable
                     as int?,
         rootUrl:
-            rootUrl == freezed
+            freezed == rootUrl
                 ? _value.rootUrl
                 : rootUrl // ignore: cast_nullable_to_non_nullable
                     as String?,
@@ -259,8 +278,8 @@ class __$$_TestCopyWithImpl<$Res> extends _$TestCopyWithImpl<$Res> implements _$
 
 /// @nodoc
 @JsonSerializable()
-class _$_Test implements _Test {
-  _$_Test({
+class _$TestImpl implements _Test {
+  _$TestImpl({
     required this.id,
     required this.name,
     @JsonKey(name: 'suiteID') required this.suiteId,
@@ -273,7 +292,8 @@ class _$_Test implements _Test {
     @JsonKey(name: 'root_url') this.rootUrl,
   }) : _groupIds = groupIds;
 
-  factory _$_Test.fromJson(Map<String, dynamic> json) => _$$_TestFromJson(json);
+  factory _$TestImpl.fromJson(Map<String, dynamic> json) =>
+      _$$TestImplFromJson(json);
 
   /// An opaque ID for this test.
   @override
@@ -295,6 +315,7 @@ class _$_Test implements _Test {
   @override
   @JsonKey(name: 'groupIDs')
   List<int> get groupIds {
+    if (_groupIds is EqualUnmodifiableListView) return _groupIds;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_groupIds);
   }
@@ -338,45 +359,51 @@ class _$_Test implements _Test {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Test &&
-            const DeepCollectionEquality().equals(other.id, id) &&
-            const DeepCollectionEquality().equals(other.name, name) &&
-            const DeepCollectionEquality().equals(other.suiteId, suiteId) &&
+            other is _$TestImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.suiteId, suiteId) || other.suiteId == suiteId) &&
             const DeepCollectionEquality().equals(other._groupIds, _groupIds) &&
-            const DeepCollectionEquality().equals(other.line, line) &&
-            const DeepCollectionEquality().equals(other.column, column) &&
-            const DeepCollectionEquality().equals(other.url, url) &&
-            const DeepCollectionEquality().equals(other.rootLine, rootLine) &&
-            const DeepCollectionEquality().equals(other.rootColumn, rootColumn) &&
-            const DeepCollectionEquality().equals(other.rootUrl, rootUrl));
+            (identical(other.line, line) || other.line == line) &&
+            (identical(other.column, column) || other.column == column) &&
+            (identical(other.url, url) || other.url == url) &&
+            (identical(other.rootLine, rootLine) ||
+                other.rootLine == rootLine) &&
+            (identical(other.rootColumn, rootColumn) ||
+                other.rootColumn == rootColumn) &&
+            (identical(other.rootUrl, rootUrl) || other.rootUrl == rootUrl));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
     runtimeType,
-    const DeepCollectionEquality().hash(id),
-    const DeepCollectionEquality().hash(name),
-    const DeepCollectionEquality().hash(suiteId),
+    id,
+    name,
+    suiteId,
     const DeepCollectionEquality().hash(_groupIds),
-    const DeepCollectionEquality().hash(line),
-    const DeepCollectionEquality().hash(column),
-    const DeepCollectionEquality().hash(url),
-    const DeepCollectionEquality().hash(rootLine),
-    const DeepCollectionEquality().hash(rootColumn),
-    const DeepCollectionEquality().hash(rootUrl),
+    line,
+    column,
+    url,
+    rootLine,
+    rootColumn,
+    rootUrl,
   );
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Test
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  _$$_TestCopyWith<_$_Test> get copyWith => __$$_TestCopyWithImpl<_$_Test>(this, _$identity);
+  @pragma('vm:prefer-inline')
+  _$$TestImplCopyWith<_$TestImpl> get copyWith =>
+      __$$TestImplCopyWithImpl<_$TestImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_TestToJson(this);
+    return _$$TestImplToJson(this);
   }
 }
 
@@ -392,52 +419,65 @@ abstract class _Test implements Test {
     @JsonKey(name: 'root_line') final int? rootLine,
     @JsonKey(name: 'root_column') final int? rootColumn,
     @JsonKey(name: 'root_url') final String? rootUrl,
-  }) = _$_Test;
+  }) = _$TestImpl;
 
-  factory _Test.fromJson(Map<String, dynamic> json) = _$_Test.fromJson;
+  factory _Test.fromJson(Map<String, dynamic> json) = _$TestImpl.fromJson;
 
-  @override
   /// An opaque ID for this test.
+  @override
   int get id;
-  @override
+
   /// The name of this test, including prefixes from any containing groups.
-  String get name;
   @override
+  String get name;
+
   /// The ID of the suite containing this test.
+  @override
   @JsonKey(name: 'suiteID')
   int get suiteId;
-  @override
+
   /// The IDs of groups containing this test, in order from outermost to innermost.
+  @override
   @JsonKey(name: 'groupIDs')
   List<int> get groupIds;
-  @override
+
   /// The (1-based) line on which this test was defined, or `null`.
+  @override
   int? get line;
-  @override
+
   /// The (1-based) column on which this test was defined, or `null`.
+  @override
   int? get column;
-  @override
+
   /// The URL for the file in which this test was defined, or `null`.
-  String? get url;
   @override
+  String? get url;
+
   /// The (1-based) line in the original test suite from which this test originated.
   ///
   /// Will only be present if `rootUrl` is different from `url`.
+  @override
   @JsonKey(name: 'root_line')
   int? get rootLine;
-  @override
+
   /// The (1-based) line on in the original test suite from which this test originated.
   ///
   /// Will only be present if `rootUrl` is different from `url`.
+  @override
   @JsonKey(name: 'root_column')
   int? get rootColumn;
-  @override
+
   /// The URL for the original test suite in which this test was defined.
   ///
   /// Will only be present if different from `url`.
+  @override
   @JsonKey(name: 'root_url')
   String? get rootUrl;
+
+  /// Create a copy of Test
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
-  _$$_TestCopyWith<_$_Test> get copyWith => throw _privateConstructorUsedError;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$TestImplCopyWith<_$TestImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }

--- a/lib/src/parser/json_reporter_protocol_0_1/test.g.dart
+++ b/lib/src/parser/json_reporter_protocol_0_1/test.g.dart
@@ -8,20 +8,23 @@ part of 'test.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_Test _$$_TestFromJson(Map<String, dynamic> json) => $checkedCreate(
-  r'_$_Test',
+_$TestImpl _$$TestImplFromJson(Map<String, dynamic> json) => $checkedCreate(
+  r'_$TestImpl',
   json,
   ($checkedConvert) {
-    final val = _$_Test(
-      id: $checkedConvert('id', (v) => v as int),
+    final val = _$TestImpl(
+      id: $checkedConvert('id', (v) => (v as num).toInt()),
       name: $checkedConvert('name', (v) => v as String),
-      suiteId: $checkedConvert('suiteID', (v) => v as int),
-      groupIds: $checkedConvert('groupIDs', (v) => (v as List<dynamic>).map((e) => e as int).toList()),
-      line: $checkedConvert('line', (v) => v as int?),
-      column: $checkedConvert('column', (v) => v as int?),
+      suiteId: $checkedConvert('suiteID', (v) => (v as num).toInt()),
+      groupIds: $checkedConvert(
+        'groupIDs',
+        (v) => (v as List<dynamic>).map((e) => (e as num).toInt()).toList(),
+      ),
+      line: $checkedConvert('line', (v) => (v as num?)?.toInt()),
+      column: $checkedConvert('column', (v) => (v as num?)?.toInt()),
       url: $checkedConvert('url', (v) => v as String?),
-      rootLine: $checkedConvert('root_line', (v) => v as int?),
-      rootColumn: $checkedConvert('root_column', (v) => v as int?),
+      rootLine: $checkedConvert('root_line', (v) => (v as num?)?.toInt()),
+      rootColumn: $checkedConvert('root_column', (v) => (v as num?)?.toInt()),
       rootUrl: $checkedConvert('root_url', (v) => v as String?),
     );
     return val;
@@ -35,15 +38,16 @@ _$_Test _$$_TestFromJson(Map<String, dynamic> json) => $checkedCreate(
   },
 );
 
-Map<String, dynamic> _$$_TestToJson(_$_Test instance) => <String, dynamic>{
-  'id': instance.id,
-  'name': instance.name,
-  'suiteID': instance.suiteId,
-  'groupIDs': instance.groupIds,
-  'line': instance.line,
-  'column': instance.column,
-  'url': instance.url,
-  'root_line': instance.rootLine,
-  'root_column': instance.rootColumn,
-  'root_url': instance.rootUrl,
-};
+Map<String, dynamic> _$$TestImplToJson(_$TestImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'suiteID': instance.suiteId,
+      'groupIDs': instance.groupIds,
+      'line': instance.line,
+      'column': instance.column,
+      'url': instance.url,
+      'root_line': instance.rootLine,
+      'root_column': instance.rootColumn,
+      'root_url': instance.rootUrl,
+    };

--- a/lib/src/parser/json_reporter_protocol_0_1/test.g.dart
+++ b/lib/src/parser/json_reporter_protocol_0_1/test.g.dart
@@ -9,42 +9,41 @@ part of 'test.dart';
 // **************************************************************************
 
 _$_Test _$$_TestFromJson(Map<String, dynamic> json) => $checkedCreate(
-      r'_$_Test',
-      json,
-      ($checkedConvert) {
-        final val = _$_Test(
-          id: $checkedConvert('id', (v) => v as int),
-          name: $checkedConvert('name', (v) => v as String),
-          suiteId: $checkedConvert('suiteID', (v) => v as int),
-          groupIds: $checkedConvert('groupIDs',
-              (v) => (v as List<dynamic>).map((e) => e as int).toList()),
-          line: $checkedConvert('line', (v) => v as int?),
-          column: $checkedConvert('column', (v) => v as int?),
-          url: $checkedConvert('url', (v) => v as String?),
-          rootLine: $checkedConvert('root_line', (v) => v as int?),
-          rootColumn: $checkedConvert('root_column', (v) => v as int?),
-          rootUrl: $checkedConvert('root_url', (v) => v as String?),
-        );
-        return val;
-      },
-      fieldKeyMap: const {
-        'suiteId': 'suiteID',
-        'groupIds': 'groupIDs',
-        'rootLine': 'root_line',
-        'rootColumn': 'root_column',
-        'rootUrl': 'root_url'
-      },
+  r'_$_Test',
+  json,
+  ($checkedConvert) {
+    final val = _$_Test(
+      id: $checkedConvert('id', (v) => v as int),
+      name: $checkedConvert('name', (v) => v as String),
+      suiteId: $checkedConvert('suiteID', (v) => v as int),
+      groupIds: $checkedConvert('groupIDs', (v) => (v as List<dynamic>).map((e) => e as int).toList()),
+      line: $checkedConvert('line', (v) => v as int?),
+      column: $checkedConvert('column', (v) => v as int?),
+      url: $checkedConvert('url', (v) => v as String?),
+      rootLine: $checkedConvert('root_line', (v) => v as int?),
+      rootColumn: $checkedConvert('root_column', (v) => v as int?),
+      rootUrl: $checkedConvert('root_url', (v) => v as String?),
     );
+    return val;
+  },
+  fieldKeyMap: const {
+    'suiteId': 'suiteID',
+    'groupIds': 'groupIDs',
+    'rootLine': 'root_line',
+    'rootColumn': 'root_column',
+    'rootUrl': 'root_url',
+  },
+);
 
 Map<String, dynamic> _$$_TestToJson(_$_Test instance) => <String, dynamic>{
-      'id': instance.id,
-      'name': instance.name,
-      'suiteID': instance.suiteId,
-      'groupIDs': instance.groupIds,
-      'line': instance.line,
-      'column': instance.column,
-      'url': instance.url,
-      'root_line': instance.rootLine,
-      'root_column': instance.rootColumn,
-      'root_url': instance.rootUrl,
-    };
+  'id': instance.id,
+  'name': instance.name,
+  'suiteID': instance.suiteId,
+  'groupIDs': instance.groupIds,
+  'line': instance.line,
+  'column': instance.column,
+  'url': instance.url,
+  'root_line': instance.rootLine,
+  'root_column': instance.rootColumn,
+  'root_url': instance.rootUrl,
+};

--- a/lib/src/parser/json_reporter_protocol_0_1/test.g.dart
+++ b/lib/src/parser/json_reporter_protocol_0_1/test.g.dart
@@ -16,10 +16,7 @@ _$TestImpl _$$TestImplFromJson(Map<String, dynamic> json) => $checkedCreate(
       id: $checkedConvert('id', (v) => (v as num).toInt()),
       name: $checkedConvert('name', (v) => v as String),
       suiteId: $checkedConvert('suiteID', (v) => (v as num).toInt()),
-      groupIds: $checkedConvert(
-        'groupIDs',
-        (v) => (v as List<dynamic>).map((e) => (e as num).toInt()).toList(),
-      ),
+      groupIds: $checkedConvert('groupIDs', (v) => (v as List<dynamic>).map((e) => (e as num).toInt()).toList()),
       line: $checkedConvert('line', (v) => (v as num?)?.toInt()),
       column: $checkedConvert('column', (v) => (v as num?)?.toInt()),
       url: $checkedConvert('url', (v) => v as String?),
@@ -38,16 +35,15 @@ _$TestImpl _$$TestImplFromJson(Map<String, dynamic> json) => $checkedCreate(
   },
 );
 
-Map<String, dynamic> _$$TestImplToJson(_$TestImpl instance) =>
-    <String, dynamic>{
-      'id': instance.id,
-      'name': instance.name,
-      'suiteID': instance.suiteId,
-      'groupIDs': instance.groupIds,
-      'line': instance.line,
-      'column': instance.column,
-      'url': instance.url,
-      'root_line': instance.rootLine,
-      'root_column': instance.rootColumn,
-      'root_url': instance.rootUrl,
-    };
+Map<String, dynamic> _$$TestImplToJson(_$TestImpl instance) => <String, dynamic>{
+  'id': instance.id,
+  'name': instance.name,
+  'suiteID': instance.suiteId,
+  'groupIDs': instance.groupIds,
+  'line': instance.line,
+  'column': instance.column,
+  'url': instance.url,
+  'root_line': instance.rootLine,
+  'root_column': instance.rootColumn,
+  'root_url': instance.rootUrl,
+};

--- a/lib/src/parser/json_reporter_protocol_0_1/test.g.dart
+++ b/lib/src/parser/json_reporter_protocol_0_1/test.g.dart
@@ -16,7 +16,10 @@ _$TestImpl _$$TestImplFromJson(Map<String, dynamic> json) => $checkedCreate(
       id: $checkedConvert('id', (v) => (v as num).toInt()),
       name: $checkedConvert('name', (v) => v as String),
       suiteId: $checkedConvert('suiteID', (v) => (v as num).toInt()),
-      groupIds: $checkedConvert('groupIDs', (v) => (v as List<dynamic>).map((e) => (e as num).toInt()).toList()),
+      groupIds: $checkedConvert(
+        'groupIDs',
+        (v) => (v as List<dynamic>).map((e) => (e as num).toInt()).toList(),
+      ),
       line: $checkedConvert('line', (v) => (v as num?)?.toInt()),
       column: $checkedConvert('column', (v) => (v as num?)?.toInt()),
       url: $checkedConvert('url', (v) => v as String?),
@@ -35,15 +38,16 @@ _$TestImpl _$$TestImplFromJson(Map<String, dynamic> json) => $checkedCreate(
   },
 );
 
-Map<String, dynamic> _$$TestImplToJson(_$TestImpl instance) => <String, dynamic>{
-  'id': instance.id,
-  'name': instance.name,
-  'suiteID': instance.suiteId,
-  'groupIDs': instance.groupIds,
-  'line': instance.line,
-  'column': instance.column,
-  'url': instance.url,
-  'root_line': instance.rootLine,
-  'root_column': instance.rootColumn,
-  'root_url': instance.rootUrl,
-};
+Map<String, dynamic> _$$TestImplToJson(_$TestImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'suiteID': instance.suiteId,
+      'groupIDs': instance.groupIds,
+      'line': instance.line,
+      'column': instance.column,
+      'url': instance.url,
+      'root_line': instance.rootLine,
+      'root_column': instance.rootColumn,
+      'root_url': instance.rootUrl,
+    };

--- a/lib/src/processing/models/problem.freezed.dart
+++ b/lib/src/processing/models/problem.freezed.dart
@@ -12,7 +12,8 @@ part of 'problem.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods',
+);
 
 /// @nodoc
 mixin _$Problem {
@@ -31,8 +32,7 @@ mixin _$Problem {
 
 /// @nodoc
 abstract class $ProblemCopyWith<$Res> {
-  factory $ProblemCopyWith(Problem value, $Res Function(Problem) then) =
-      _$ProblemCopyWithImpl<$Res>;
+  factory $ProblemCopyWith(Problem value, $Res Function(Problem) then) = _$ProblemCopyWithImpl<$Res>;
   $Res call({String message, String stacktrace, bool isFailure});
 }
 
@@ -45,76 +45,72 @@ class _$ProblemCopyWithImpl<$Res> implements $ProblemCopyWith<$Res> {
   final $Res Function(Problem) _then;
 
   @override
-  $Res call({
-    Object? message = freezed,
-    Object? stacktrace = freezed,
-    Object? isFailure = freezed,
-  }) {
-    return _then(_value.copyWith(
-      message: message == freezed
-          ? _value.message
-          : message // ignore: cast_nullable_to_non_nullable
-              as String,
-      stacktrace: stacktrace == freezed
-          ? _value.stacktrace
-          : stacktrace // ignore: cast_nullable_to_non_nullable
-              as String,
-      isFailure: isFailure == freezed
-          ? _value.isFailure
-          : isFailure // ignore: cast_nullable_to_non_nullable
-              as bool,
-    ));
+  $Res call({Object? message = freezed, Object? stacktrace = freezed, Object? isFailure = freezed}) {
+    return _then(
+      _value.copyWith(
+        message:
+            message == freezed
+                ? _value.message
+                : message // ignore: cast_nullable_to_non_nullable
+                    as String,
+        stacktrace:
+            stacktrace == freezed
+                ? _value.stacktrace
+                : stacktrace // ignore: cast_nullable_to_non_nullable
+                    as String,
+        isFailure:
+            isFailure == freezed
+                ? _value.isFailure
+                : isFailure // ignore: cast_nullable_to_non_nullable
+                    as bool,
+      ),
+    );
   }
 }
 
 /// @nodoc
 abstract class _$$_ProblemCopyWith<$Res> implements $ProblemCopyWith<$Res> {
-  factory _$$_ProblemCopyWith(
-          _$_Problem value, $Res Function(_$_Problem) then) =
-      __$$_ProblemCopyWithImpl<$Res>;
+  factory _$$_ProblemCopyWith(_$_Problem value, $Res Function(_$_Problem) then) = __$$_ProblemCopyWithImpl<$Res>;
   @override
   $Res call({String message, String stacktrace, bool isFailure});
 }
 
 /// @nodoc
-class __$$_ProblemCopyWithImpl<$Res> extends _$ProblemCopyWithImpl<$Res>
-    implements _$$_ProblemCopyWith<$Res> {
+class __$$_ProblemCopyWithImpl<$Res> extends _$ProblemCopyWithImpl<$Res> implements _$$_ProblemCopyWith<$Res> {
   __$$_ProblemCopyWithImpl(_$_Problem _value, $Res Function(_$_Problem) _then)
-      : super(_value, (v) => _then(v as _$_Problem));
+    : super(_value, (v) => _then(v as _$_Problem));
 
   @override
   _$_Problem get _value => super._value as _$_Problem;
 
   @override
-  $Res call({
-    Object? message = freezed,
-    Object? stacktrace = freezed,
-    Object? isFailure = freezed,
-  }) {
-    return _then(_$_Problem(
-      message: message == freezed
-          ? _value.message
-          : message // ignore: cast_nullable_to_non_nullable
-              as String,
-      stacktrace: stacktrace == freezed
-          ? _value.stacktrace
-          : stacktrace // ignore: cast_nullable_to_non_nullable
-              as String,
-      isFailure: isFailure == freezed
-          ? _value.isFailure
-          : isFailure // ignore: cast_nullable_to_non_nullable
-              as bool,
-    ));
+  $Res call({Object? message = freezed, Object? stacktrace = freezed, Object? isFailure = freezed}) {
+    return _then(
+      _$_Problem(
+        message:
+            message == freezed
+                ? _value.message
+                : message // ignore: cast_nullable_to_non_nullable
+                    as String,
+        stacktrace:
+            stacktrace == freezed
+                ? _value.stacktrace
+                : stacktrace // ignore: cast_nullable_to_non_nullable
+                    as String,
+        isFailure:
+            isFailure == freezed
+                ? _value.isFailure
+                : isFailure // ignore: cast_nullable_to_non_nullable
+                    as bool,
+      ),
+    );
   }
 }
 
 /// @nodoc
 
 class _$_Problem implements _Problem {
-  _$_Problem(
-      {required this.message,
-      required this.stacktrace,
-      required this.isFailure});
+  _$_Problem({required this.message, required this.stacktrace, required this.isFailure});
 
   /// The error's message.
   @override
@@ -139,44 +135,37 @@ class _$_Problem implements _Problem {
         (other.runtimeType == runtimeType &&
             other is _$_Problem &&
             const DeepCollectionEquality().equals(other.message, message) &&
-            const DeepCollectionEquality()
-                .equals(other.stacktrace, stacktrace) &&
+            const DeepCollectionEquality().equals(other.stacktrace, stacktrace) &&
             const DeepCollectionEquality().equals(other.isFailure, isFailure));
   }
 
   @override
   int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(message),
-      const DeepCollectionEquality().hash(stacktrace),
-      const DeepCollectionEquality().hash(isFailure));
+    runtimeType,
+    const DeepCollectionEquality().hash(message),
+    const DeepCollectionEquality().hash(stacktrace),
+    const DeepCollectionEquality().hash(isFailure),
+  );
 
   @JsonKey(ignore: true)
   @override
-  _$$_ProblemCopyWith<_$_Problem> get copyWith =>
-      __$$_ProblemCopyWithImpl<_$_Problem>(this, _$identity);
+  _$$_ProblemCopyWith<_$_Problem> get copyWith => __$$_ProblemCopyWithImpl<_$_Problem>(this, _$identity);
 }
 
 abstract class _Problem implements Problem {
-  factory _Problem(
-      {required final String message,
-      required final String stacktrace,
-      required final bool isFailure}) = _$_Problem;
+  factory _Problem({required final String message, required final String stacktrace, required final bool isFailure}) =
+      _$_Problem;
 
   @override
-
   /// The error's message.
   String get message;
   @override
-
   /// The error's stack trace, in the [stack_trace](https://pub.dev/packages/stack_trace) package format
   String get stacktrace;
   @override
-
   /// Whether the error was a `TestFailure`
   bool get isFailure;
   @override
   @JsonKey(ignore: true)
-  _$$_ProblemCopyWith<_$_Problem> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$_ProblemCopyWith<_$_Problem> get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/processing/models/problem.freezed.dart
+++ b/lib/src/processing/models/problem.freezed.dart
@@ -1,7 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
-// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
 part of 'problem.dart';
 
@@ -12,7 +12,7 @@ part of 'problem.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods',
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
 );
 
 /// @nodoc
@@ -26,79 +26,105 @@ mixin _$Problem {
   /// Whether the error was a `TestFailure`
   bool get isFailure => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Problem
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ProblemCopyWith<Problem> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class $ProblemCopyWith<$Res> {
-  factory $ProblemCopyWith(Problem value, $Res Function(Problem) then) = _$ProblemCopyWithImpl<$Res>;
+  factory $ProblemCopyWith(Problem value, $Res Function(Problem) then) =
+      _$ProblemCopyWithImpl<$Res, Problem>;
+  @useResult
   $Res call({String message, String stacktrace, bool isFailure});
 }
 
 /// @nodoc
-class _$ProblemCopyWithImpl<$Res> implements $ProblemCopyWith<$Res> {
+class _$ProblemCopyWithImpl<$Res, $Val extends Problem>
+    implements $ProblemCopyWith<$Res> {
   _$ProblemCopyWithImpl(this._value, this._then);
 
-  final Problem _value;
   // ignore: unused_field
-  final $Res Function(Problem) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  /// Create a copy of Problem
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
   @override
-  $Res call({Object? message = freezed, Object? stacktrace = freezed, Object? isFailure = freezed}) {
+  $Res call({
+    Object? message = null,
+    Object? stacktrace = null,
+    Object? isFailure = null,
+  }) {
     return _then(
       _value.copyWith(
-        message:
-            message == freezed
-                ? _value.message
-                : message // ignore: cast_nullable_to_non_nullable
-                    as String,
-        stacktrace:
-            stacktrace == freezed
-                ? _value.stacktrace
-                : stacktrace // ignore: cast_nullable_to_non_nullable
-                    as String,
-        isFailure:
-            isFailure == freezed
-                ? _value.isFailure
-                : isFailure // ignore: cast_nullable_to_non_nullable
-                    as bool,
-      ),
+            message:
+                null == message
+                    ? _value.message
+                    : message // ignore: cast_nullable_to_non_nullable
+                        as String,
+            stacktrace:
+                null == stacktrace
+                    ? _value.stacktrace
+                    : stacktrace // ignore: cast_nullable_to_non_nullable
+                        as String,
+            isFailure:
+                null == isFailure
+                    ? _value.isFailure
+                    : isFailure // ignore: cast_nullable_to_non_nullable
+                        as bool,
+          )
+          as $Val,
     );
   }
 }
 
 /// @nodoc
-abstract class _$$_ProblemCopyWith<$Res> implements $ProblemCopyWith<$Res> {
-  factory _$$_ProblemCopyWith(_$_Problem value, $Res Function(_$_Problem) then) = __$$_ProblemCopyWithImpl<$Res>;
+abstract class _$$ProblemImplCopyWith<$Res> implements $ProblemCopyWith<$Res> {
+  factory _$$ProblemImplCopyWith(
+    _$ProblemImpl value,
+    $Res Function(_$ProblemImpl) then,
+  ) = __$$ProblemImplCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call({String message, String stacktrace, bool isFailure});
 }
 
 /// @nodoc
-class __$$_ProblemCopyWithImpl<$Res> extends _$ProblemCopyWithImpl<$Res> implements _$$_ProblemCopyWith<$Res> {
-  __$$_ProblemCopyWithImpl(_$_Problem _value, $Res Function(_$_Problem) _then)
-    : super(_value, (v) => _then(v as _$_Problem));
+class __$$ProblemImplCopyWithImpl<$Res>
+    extends _$ProblemCopyWithImpl<$Res, _$ProblemImpl>
+    implements _$$ProblemImplCopyWith<$Res> {
+  __$$ProblemImplCopyWithImpl(
+    _$ProblemImpl _value,
+    $Res Function(_$ProblemImpl) _then,
+  ) : super(_value, _then);
 
+  /// Create a copy of Problem
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
   @override
-  _$_Problem get _value => super._value as _$_Problem;
-
-  @override
-  $Res call({Object? message = freezed, Object? stacktrace = freezed, Object? isFailure = freezed}) {
+  $Res call({
+    Object? message = null,
+    Object? stacktrace = null,
+    Object? isFailure = null,
+  }) {
     return _then(
-      _$_Problem(
+      _$ProblemImpl(
         message:
-            message == freezed
+            null == message
                 ? _value.message
                 : message // ignore: cast_nullable_to_non_nullable
                     as String,
         stacktrace:
-            stacktrace == freezed
+            null == stacktrace
                 ? _value.stacktrace
                 : stacktrace // ignore: cast_nullable_to_non_nullable
                     as String,
         isFailure:
-            isFailure == freezed
+            null == isFailure
                 ? _value.isFailure
                 : isFailure // ignore: cast_nullable_to_non_nullable
                     as bool,
@@ -109,8 +135,12 @@ class __$$_ProblemCopyWithImpl<$Res> extends _$ProblemCopyWithImpl<$Res> impleme
 
 /// @nodoc
 
-class _$_Problem implements _Problem {
-  _$_Problem({required this.message, required this.stacktrace, required this.isFailure});
+class _$ProblemImpl implements _Problem {
+  _$ProblemImpl({
+    required this.message,
+    required this.stacktrace,
+    required this.isFailure,
+  });
 
   /// The error's message.
   @override
@@ -130,42 +160,52 @@ class _$_Problem implements _Problem {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Problem &&
-            const DeepCollectionEquality().equals(other.message, message) &&
-            const DeepCollectionEquality().equals(other.stacktrace, stacktrace) &&
-            const DeepCollectionEquality().equals(other.isFailure, isFailure));
+            other is _$ProblemImpl &&
+            (identical(other.message, message) || other.message == message) &&
+            (identical(other.stacktrace, stacktrace) ||
+                other.stacktrace == stacktrace) &&
+            (identical(other.isFailure, isFailure) ||
+                other.isFailure == isFailure));
   }
 
   @override
-  int get hashCode => Object.hash(
-    runtimeType,
-    const DeepCollectionEquality().hash(message),
-    const DeepCollectionEquality().hash(stacktrace),
-    const DeepCollectionEquality().hash(isFailure),
-  );
+  int get hashCode => Object.hash(runtimeType, message, stacktrace, isFailure);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Problem
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  _$$_ProblemCopyWith<_$_Problem> get copyWith => __$$_ProblemCopyWithImpl<_$_Problem>(this, _$identity);
+  @pragma('vm:prefer-inline')
+  _$$ProblemImplCopyWith<_$ProblemImpl> get copyWith =>
+      __$$ProblemImplCopyWithImpl<_$ProblemImpl>(this, _$identity);
 }
 
 abstract class _Problem implements Problem {
-  factory _Problem({required final String message, required final String stacktrace, required final bool isFailure}) =
-      _$_Problem;
+  factory _Problem({
+    required final String message,
+    required final String stacktrace,
+    required final bool isFailure,
+  }) = _$ProblemImpl;
 
-  @override
   /// The error's message.
+  @override
   String get message;
-  @override
+
   /// The error's stack trace, in the [stack_trace](https://pub.dev/packages/stack_trace) package format
+  @override
   String get stacktrace;
-  @override
+
   /// Whether the error was a `TestFailure`
-  bool get isFailure;
   @override
-  @JsonKey(ignore: true)
-  _$$_ProblemCopyWith<_$_Problem> get copyWith => throw _privateConstructorUsedError;
+  bool get isFailure;
+
+  /// Create a copy of Problem
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ProblemImplCopyWith<_$ProblemImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }

--- a/lib/src/processing/models/problem.freezed.dart
+++ b/lib/src/processing/models/problem.freezed.dart
@@ -34,15 +34,13 @@ mixin _$Problem {
 
 /// @nodoc
 abstract class $ProblemCopyWith<$Res> {
-  factory $ProblemCopyWith(Problem value, $Res Function(Problem) then) =
-      _$ProblemCopyWithImpl<$Res, Problem>;
+  factory $ProblemCopyWith(Problem value, $Res Function(Problem) then) = _$ProblemCopyWithImpl<$Res, Problem>;
   @useResult
   $Res call({String message, String stacktrace, bool isFailure});
 }
 
 /// @nodoc
-class _$ProblemCopyWithImpl<$Res, $Val extends Problem>
-    implements $ProblemCopyWith<$Res> {
+class _$ProblemCopyWithImpl<$Res, $Val extends Problem> implements $ProblemCopyWith<$Res> {
   _$ProblemCopyWithImpl(this._value, this._then);
 
   // ignore: unused_field
@@ -54,11 +52,7 @@ class _$ProblemCopyWithImpl<$Res, $Val extends Problem>
   /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
-  $Res call({
-    Object? message = null,
-    Object? stacktrace = null,
-    Object? isFailure = null,
-  }) {
+  $Res call({Object? message = null, Object? stacktrace = null, Object? isFailure = null}) {
     return _then(
       _value.copyWith(
             message:
@@ -84,33 +78,23 @@ class _$ProblemCopyWithImpl<$Res, $Val extends Problem>
 
 /// @nodoc
 abstract class _$$ProblemImplCopyWith<$Res> implements $ProblemCopyWith<$Res> {
-  factory _$$ProblemImplCopyWith(
-    _$ProblemImpl value,
-    $Res Function(_$ProblemImpl) then,
-  ) = __$$ProblemImplCopyWithImpl<$Res>;
+  factory _$$ProblemImplCopyWith(_$ProblemImpl value, $Res Function(_$ProblemImpl) then) =
+      __$$ProblemImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String message, String stacktrace, bool isFailure});
 }
 
 /// @nodoc
-class __$$ProblemImplCopyWithImpl<$Res>
-    extends _$ProblemCopyWithImpl<$Res, _$ProblemImpl>
+class __$$ProblemImplCopyWithImpl<$Res> extends _$ProblemCopyWithImpl<$Res, _$ProblemImpl>
     implements _$$ProblemImplCopyWith<$Res> {
-  __$$ProblemImplCopyWithImpl(
-    _$ProblemImpl _value,
-    $Res Function(_$ProblemImpl) _then,
-  ) : super(_value, _then);
+  __$$ProblemImplCopyWithImpl(_$ProblemImpl _value, $Res Function(_$ProblemImpl) _then) : super(_value, _then);
 
   /// Create a copy of Problem
   /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
-  $Res call({
-    Object? message = null,
-    Object? stacktrace = null,
-    Object? isFailure = null,
-  }) {
+  $Res call({Object? message = null, Object? stacktrace = null, Object? isFailure = null}) {
     return _then(
       _$ProblemImpl(
         message:
@@ -136,11 +120,7 @@ class __$$ProblemImplCopyWithImpl<$Res>
 /// @nodoc
 
 class _$ProblemImpl implements _Problem {
-  _$ProblemImpl({
-    required this.message,
-    required this.stacktrace,
-    required this.isFailure,
-  });
+  _$ProblemImpl({required this.message, required this.stacktrace, required this.isFailure});
 
   /// The error's message.
   @override
@@ -165,10 +145,8 @@ class _$ProblemImpl implements _Problem {
         (other.runtimeType == runtimeType &&
             other is _$ProblemImpl &&
             (identical(other.message, message) || other.message == message) &&
-            (identical(other.stacktrace, stacktrace) ||
-                other.stacktrace == stacktrace) &&
-            (identical(other.isFailure, isFailure) ||
-                other.isFailure == isFailure));
+            (identical(other.stacktrace, stacktrace) || other.stacktrace == stacktrace) &&
+            (identical(other.isFailure, isFailure) || other.isFailure == isFailure));
   }
 
   @override
@@ -179,16 +157,12 @@ class _$ProblemImpl implements _Problem {
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$ProblemImplCopyWith<_$ProblemImpl> get copyWith =>
-      __$$ProblemImplCopyWithImpl<_$ProblemImpl>(this, _$identity);
+  _$$ProblemImplCopyWith<_$ProblemImpl> get copyWith => __$$ProblemImplCopyWithImpl<_$ProblemImpl>(this, _$identity);
 }
 
 abstract class _Problem implements Problem {
-  factory _Problem({
-    required final String message,
-    required final String stacktrace,
-    required final bool isFailure,
-  }) = _$ProblemImpl;
+  factory _Problem({required final String message, required final String stacktrace, required final bool isFailure}) =
+      _$ProblemImpl;
 
   /// The error's message.
   @override
@@ -206,6 +180,5 @@ abstract class _Problem implements Problem {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$ProblemImplCopyWith<_$ProblemImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$ProblemImplCopyWith<_$ProblemImpl> get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/processing/models/problem.freezed.dart
+++ b/lib/src/processing/models/problem.freezed.dart
@@ -34,13 +34,15 @@ mixin _$Problem {
 
 /// @nodoc
 abstract class $ProblemCopyWith<$Res> {
-  factory $ProblemCopyWith(Problem value, $Res Function(Problem) then) = _$ProblemCopyWithImpl<$Res, Problem>;
+  factory $ProblemCopyWith(Problem value, $Res Function(Problem) then) =
+      _$ProblemCopyWithImpl<$Res, Problem>;
   @useResult
   $Res call({String message, String stacktrace, bool isFailure});
 }
 
 /// @nodoc
-class _$ProblemCopyWithImpl<$Res, $Val extends Problem> implements $ProblemCopyWith<$Res> {
+class _$ProblemCopyWithImpl<$Res, $Val extends Problem>
+    implements $ProblemCopyWith<$Res> {
   _$ProblemCopyWithImpl(this._value, this._then);
 
   // ignore: unused_field
@@ -52,7 +54,11 @@ class _$ProblemCopyWithImpl<$Res, $Val extends Problem> implements $ProblemCopyW
   /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
-  $Res call({Object? message = null, Object? stacktrace = null, Object? isFailure = null}) {
+  $Res call({
+    Object? message = null,
+    Object? stacktrace = null,
+    Object? isFailure = null,
+  }) {
     return _then(
       _value.copyWith(
             message:
@@ -78,23 +84,33 @@ class _$ProblemCopyWithImpl<$Res, $Val extends Problem> implements $ProblemCopyW
 
 /// @nodoc
 abstract class _$$ProblemImplCopyWith<$Res> implements $ProblemCopyWith<$Res> {
-  factory _$$ProblemImplCopyWith(_$ProblemImpl value, $Res Function(_$ProblemImpl) then) =
-      __$$ProblemImplCopyWithImpl<$Res>;
+  factory _$$ProblemImplCopyWith(
+    _$ProblemImpl value,
+    $Res Function(_$ProblemImpl) then,
+  ) = __$$ProblemImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String message, String stacktrace, bool isFailure});
 }
 
 /// @nodoc
-class __$$ProblemImplCopyWithImpl<$Res> extends _$ProblemCopyWithImpl<$Res, _$ProblemImpl>
+class __$$ProblemImplCopyWithImpl<$Res>
+    extends _$ProblemCopyWithImpl<$Res, _$ProblemImpl>
     implements _$$ProblemImplCopyWith<$Res> {
-  __$$ProblemImplCopyWithImpl(_$ProblemImpl _value, $Res Function(_$ProblemImpl) _then) : super(_value, _then);
+  __$$ProblemImplCopyWithImpl(
+    _$ProblemImpl _value,
+    $Res Function(_$ProblemImpl) _then,
+  ) : super(_value, _then);
 
   /// Create a copy of Problem
   /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
-  $Res call({Object? message = null, Object? stacktrace = null, Object? isFailure = null}) {
+  $Res call({
+    Object? message = null,
+    Object? stacktrace = null,
+    Object? isFailure = null,
+  }) {
     return _then(
       _$ProblemImpl(
         message:
@@ -120,7 +136,11 @@ class __$$ProblemImplCopyWithImpl<$Res> extends _$ProblemCopyWithImpl<$Res, _$Pr
 /// @nodoc
 
 class _$ProblemImpl implements _Problem {
-  _$ProblemImpl({required this.message, required this.stacktrace, required this.isFailure});
+  _$ProblemImpl({
+    required this.message,
+    required this.stacktrace,
+    required this.isFailure,
+  });
 
   /// The error's message.
   @override
@@ -145,8 +165,10 @@ class _$ProblemImpl implements _Problem {
         (other.runtimeType == runtimeType &&
             other is _$ProblemImpl &&
             (identical(other.message, message) || other.message == message) &&
-            (identical(other.stacktrace, stacktrace) || other.stacktrace == stacktrace) &&
-            (identical(other.isFailure, isFailure) || other.isFailure == isFailure));
+            (identical(other.stacktrace, stacktrace) ||
+                other.stacktrace == stacktrace) &&
+            (identical(other.isFailure, isFailure) ||
+                other.isFailure == isFailure));
   }
 
   @override
@@ -157,12 +179,16 @@ class _$ProblemImpl implements _Problem {
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$ProblemImplCopyWith<_$ProblemImpl> get copyWith => __$$ProblemImplCopyWithImpl<_$ProblemImpl>(this, _$identity);
+  _$$ProblemImplCopyWith<_$ProblemImpl> get copyWith =>
+      __$$ProblemImplCopyWithImpl<_$ProblemImpl>(this, _$identity);
 }
 
 abstract class _Problem implements Problem {
-  factory _Problem({required final String message, required final String stacktrace, required final bool isFailure}) =
-      _$ProblemImpl;
+  factory _Problem({
+    required final String message,
+    required final String stacktrace,
+    required final bool isFailure,
+  }) = _$ProblemImpl;
 
   /// The error's message.
   @override
@@ -180,5 +206,6 @@ abstract class _Problem implements Problem {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$ProblemImplCopyWith<_$ProblemImpl> get copyWith => throw _privateConstructorUsedError;
+  _$$ProblemImplCopyWith<_$ProblemImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }

--- a/lib/src/processing/models/report.freezed.dart
+++ b/lib/src/processing/models/report.freezed.dart
@@ -12,7 +12,8 @@ part of 'report.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods',
+);
 
 /// @nodoc
 mixin _$Report {
@@ -28,8 +29,7 @@ mixin _$Report {
 
 /// @nodoc
 abstract class $ReportCopyWith<$Res> {
-  factory $ReportCopyWith(Report value, $Res Function(Report) then) =
-      _$ReportCopyWithImpl<$Res>;
+  factory $ReportCopyWith(Report value, $Res Function(Report) then) = _$ReportCopyWithImpl<$Res>;
   $Res call({Iterable<Suite> suites, DateTime? timestamp});
 }
 
@@ -42,55 +42,55 @@ class _$ReportCopyWithImpl<$Res> implements $ReportCopyWith<$Res> {
   final $Res Function(Report) _then;
 
   @override
-  $Res call({
-    Object? suites = freezed,
-    Object? timestamp = freezed,
-  }) {
-    return _then(_value.copyWith(
-      suites: suites == freezed
-          ? _value.suites
-          : suites // ignore: cast_nullable_to_non_nullable
-              as Iterable<Suite>,
-      timestamp: timestamp == freezed
-          ? _value.timestamp
-          : timestamp // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-    ));
+  $Res call({Object? suites = freezed, Object? timestamp = freezed}) {
+    return _then(
+      _value.copyWith(
+        suites:
+            suites == freezed
+                ? _value.suites
+                : suites // ignore: cast_nullable_to_non_nullable
+                    as Iterable<Suite>,
+        timestamp:
+            timestamp == freezed
+                ? _value.timestamp
+                : timestamp // ignore: cast_nullable_to_non_nullable
+                    as DateTime?,
+      ),
+    );
   }
 }
 
 /// @nodoc
 abstract class _$$_ReportCopyWith<$Res> implements $ReportCopyWith<$Res> {
-  factory _$$_ReportCopyWith(_$_Report value, $Res Function(_$_Report) then) =
-      __$$_ReportCopyWithImpl<$Res>;
+  factory _$$_ReportCopyWith(_$_Report value, $Res Function(_$_Report) then) = __$$_ReportCopyWithImpl<$Res>;
   @override
   $Res call({Iterable<Suite> suites, DateTime? timestamp});
 }
 
 /// @nodoc
-class __$$_ReportCopyWithImpl<$Res> extends _$ReportCopyWithImpl<$Res>
-    implements _$$_ReportCopyWith<$Res> {
+class __$$_ReportCopyWithImpl<$Res> extends _$ReportCopyWithImpl<$Res> implements _$$_ReportCopyWith<$Res> {
   __$$_ReportCopyWithImpl(_$_Report _value, $Res Function(_$_Report) _then)
-      : super(_value, (v) => _then(v as _$_Report));
+    : super(_value, (v) => _then(v as _$_Report));
 
   @override
   _$_Report get _value => super._value as _$_Report;
 
   @override
-  $Res call({
-    Object? suites = freezed,
-    Object? timestamp = freezed,
-  }) {
-    return _then(_$_Report(
-      suites: suites == freezed
-          ? _value.suites
-          : suites // ignore: cast_nullable_to_non_nullable
-              as Iterable<Suite>,
-      timestamp: timestamp == freezed
-          ? _value.timestamp
-          : timestamp // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-    ));
+  $Res call({Object? suites = freezed, Object? timestamp = freezed}) {
+    return _then(
+      _$_Report(
+        suites:
+            suites == freezed
+                ? _value.suites
+                : suites // ignore: cast_nullable_to_non_nullable
+                    as Iterable<Suite>,
+        timestamp:
+            timestamp == freezed
+                ? _value.timestamp
+                : timestamp // ignore: cast_nullable_to_non_nullable
+                    as DateTime?,
+      ),
+    );
   }
 }
 
@@ -123,31 +123,26 @@ class _$_Report implements _Report {
 
   @override
   int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(suites),
-      const DeepCollectionEquality().hash(timestamp));
+    runtimeType,
+    const DeepCollectionEquality().hash(suites),
+    const DeepCollectionEquality().hash(timestamp),
+  );
 
   @JsonKey(ignore: true)
   @override
-  _$$_ReportCopyWith<_$_Report> get copyWith =>
-      __$$_ReportCopyWithImpl<_$_Report>(this, _$identity);
+  _$$_ReportCopyWith<_$_Report> get copyWith => __$$_ReportCopyWithImpl<_$_Report>(this, _$identity);
 }
 
 abstract class _Report implements Report {
-  factory _Report(
-      {required final Iterable<Suite> suites,
-      final DateTime? timestamp}) = _$_Report;
+  factory _Report({required final Iterable<Suite> suites, final DateTime? timestamp}) = _$_Report;
 
   @override
-
   /// The Suites in this report
   Iterable<Suite> get suites;
   @override
-
   /// The optional timestamp of the tests
   DateTime? get timestamp;
   @override
   @JsonKey(ignore: true)
-  _$$_ReportCopyWith<_$_Report> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$_ReportCopyWith<_$_Report> get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/processing/models/report.freezed.dart
+++ b/lib/src/processing/models/report.freezed.dart
@@ -1,7 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
-// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
 part of 'report.dart';
 
@@ -12,7 +12,7 @@ part of 'report.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods',
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
 );
 
 /// @nodoc
@@ -23,69 +23,87 @@ mixin _$Report {
   /// The optional timestamp of the tests
   DateTime? get timestamp => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Report
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ReportCopyWith<Report> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class $ReportCopyWith<$Res> {
-  factory $ReportCopyWith(Report value, $Res Function(Report) then) = _$ReportCopyWithImpl<$Res>;
+  factory $ReportCopyWith(Report value, $Res Function(Report) then) =
+      _$ReportCopyWithImpl<$Res, Report>;
+  @useResult
   $Res call({Iterable<Suite> suites, DateTime? timestamp});
 }
 
 /// @nodoc
-class _$ReportCopyWithImpl<$Res> implements $ReportCopyWith<$Res> {
+class _$ReportCopyWithImpl<$Res, $Val extends Report>
+    implements $ReportCopyWith<$Res> {
   _$ReportCopyWithImpl(this._value, this._then);
 
-  final Report _value;
   // ignore: unused_field
-  final $Res Function(Report) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  /// Create a copy of Report
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
   @override
-  $Res call({Object? suites = freezed, Object? timestamp = freezed}) {
+  $Res call({Object? suites = null, Object? timestamp = freezed}) {
     return _then(
       _value.copyWith(
-        suites:
-            suites == freezed
-                ? _value.suites
-                : suites // ignore: cast_nullable_to_non_nullable
-                    as Iterable<Suite>,
-        timestamp:
-            timestamp == freezed
-                ? _value.timestamp
-                : timestamp // ignore: cast_nullable_to_non_nullable
-                    as DateTime?,
-      ),
+            suites:
+                null == suites
+                    ? _value.suites
+                    : suites // ignore: cast_nullable_to_non_nullable
+                        as Iterable<Suite>,
+            timestamp:
+                freezed == timestamp
+                    ? _value.timestamp
+                    : timestamp // ignore: cast_nullable_to_non_nullable
+                        as DateTime?,
+          )
+          as $Val,
     );
   }
 }
 
 /// @nodoc
-abstract class _$$_ReportCopyWith<$Res> implements $ReportCopyWith<$Res> {
-  factory _$$_ReportCopyWith(_$_Report value, $Res Function(_$_Report) then) = __$$_ReportCopyWithImpl<$Res>;
+abstract class _$$ReportImplCopyWith<$Res> implements $ReportCopyWith<$Res> {
+  factory _$$ReportImplCopyWith(
+    _$ReportImpl value,
+    $Res Function(_$ReportImpl) then,
+  ) = __$$ReportImplCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call({Iterable<Suite> suites, DateTime? timestamp});
 }
 
 /// @nodoc
-class __$$_ReportCopyWithImpl<$Res> extends _$ReportCopyWithImpl<$Res> implements _$$_ReportCopyWith<$Res> {
-  __$$_ReportCopyWithImpl(_$_Report _value, $Res Function(_$_Report) _then)
-    : super(_value, (v) => _then(v as _$_Report));
+class __$$ReportImplCopyWithImpl<$Res>
+    extends _$ReportCopyWithImpl<$Res, _$ReportImpl>
+    implements _$$ReportImplCopyWith<$Res> {
+  __$$ReportImplCopyWithImpl(
+    _$ReportImpl _value,
+    $Res Function(_$ReportImpl) _then,
+  ) : super(_value, _then);
 
+  /// Create a copy of Report
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
   @override
-  _$_Report get _value => super._value as _$_Report;
-
-  @override
-  $Res call({Object? suites = freezed, Object? timestamp = freezed}) {
+  $Res call({Object? suites = null, Object? timestamp = freezed}) {
     return _then(
-      _$_Report(
+      _$ReportImpl(
         suites:
-            suites == freezed
+            null == suites
                 ? _value.suites
                 : suites // ignore: cast_nullable_to_non_nullable
                     as Iterable<Suite>,
         timestamp:
-            timestamp == freezed
+            freezed == timestamp
                 ? _value.timestamp
                 : timestamp // ignore: cast_nullable_to_non_nullable
                     as DateTime?,
@@ -96,8 +114,8 @@ class __$$_ReportCopyWithImpl<$Res> extends _$ReportCopyWithImpl<$Res> implement
 
 /// @nodoc
 
-class _$_Report implements _Report {
-  _$_Report({required this.suites, this.timestamp});
+class _$ReportImpl implements _Report {
+  _$ReportImpl({required this.suites, this.timestamp});
 
   /// The Suites in this report
   @override
@@ -113,36 +131,49 @@ class _$_Report implements _Report {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Report &&
+            other is _$ReportImpl &&
             const DeepCollectionEquality().equals(other.suites, suites) &&
-            const DeepCollectionEquality().equals(other.timestamp, timestamp));
+            (identical(other.timestamp, timestamp) ||
+                other.timestamp == timestamp));
   }
 
   @override
   int get hashCode => Object.hash(
     runtimeType,
     const DeepCollectionEquality().hash(suites),
-    const DeepCollectionEquality().hash(timestamp),
+    timestamp,
   );
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Report
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  _$$_ReportCopyWith<_$_Report> get copyWith => __$$_ReportCopyWithImpl<_$_Report>(this, _$identity);
+  @pragma('vm:prefer-inline')
+  _$$ReportImplCopyWith<_$ReportImpl> get copyWith =>
+      __$$ReportImplCopyWithImpl<_$ReportImpl>(this, _$identity);
 }
 
 abstract class _Report implements Report {
-  factory _Report({required final Iterable<Suite> suites, final DateTime? timestamp}) = _$_Report;
+  factory _Report({
+    required final Iterable<Suite> suites,
+    final DateTime? timestamp,
+  }) = _$ReportImpl;
 
-  @override
   /// The Suites in this report
+  @override
   Iterable<Suite> get suites;
-  @override
+
   /// The optional timestamp of the tests
-  DateTime? get timestamp;
   @override
-  @JsonKey(ignore: true)
-  _$$_ReportCopyWith<_$_Report> get copyWith => throw _privateConstructorUsedError;
+  DateTime? get timestamp;
+
+  /// Create a copy of Report
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ReportImplCopyWith<_$ReportImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }

--- a/lib/src/processing/models/report.freezed.dart
+++ b/lib/src/processing/models/report.freezed.dart
@@ -31,15 +31,13 @@ mixin _$Report {
 
 /// @nodoc
 abstract class $ReportCopyWith<$Res> {
-  factory $ReportCopyWith(Report value, $Res Function(Report) then) =
-      _$ReportCopyWithImpl<$Res, Report>;
+  factory $ReportCopyWith(Report value, $Res Function(Report) then) = _$ReportCopyWithImpl<$Res, Report>;
   @useResult
   $Res call({Iterable<Suite> suites, DateTime? timestamp});
 }
 
 /// @nodoc
-class _$ReportCopyWithImpl<$Res, $Val extends Report>
-    implements $ReportCopyWith<$Res> {
+class _$ReportCopyWithImpl<$Res, $Val extends Report> implements $ReportCopyWith<$Res> {
   _$ReportCopyWithImpl(this._value, this._then);
 
   // ignore: unused_field
@@ -72,23 +70,17 @@ class _$ReportCopyWithImpl<$Res, $Val extends Report>
 
 /// @nodoc
 abstract class _$$ReportImplCopyWith<$Res> implements $ReportCopyWith<$Res> {
-  factory _$$ReportImplCopyWith(
-    _$ReportImpl value,
-    $Res Function(_$ReportImpl) then,
-  ) = __$$ReportImplCopyWithImpl<$Res>;
+  factory _$$ReportImplCopyWith(_$ReportImpl value, $Res Function(_$ReportImpl) then) =
+      __$$ReportImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({Iterable<Suite> suites, DateTime? timestamp});
 }
 
 /// @nodoc
-class __$$ReportImplCopyWithImpl<$Res>
-    extends _$ReportCopyWithImpl<$Res, _$ReportImpl>
+class __$$ReportImplCopyWithImpl<$Res> extends _$ReportCopyWithImpl<$Res, _$ReportImpl>
     implements _$$ReportImplCopyWith<$Res> {
-  __$$ReportImplCopyWithImpl(
-    _$ReportImpl _value,
-    $Res Function(_$ReportImpl) _then,
-  ) : super(_value, _then);
+  __$$ReportImplCopyWithImpl(_$ReportImpl _value, $Res Function(_$ReportImpl) _then) : super(_value, _then);
 
   /// Create a copy of Report
   /// with the given fields replaced by the non-null parameter values.
@@ -136,31 +128,22 @@ class _$ReportImpl implements _Report {
         (other.runtimeType == runtimeType &&
             other is _$ReportImpl &&
             const DeepCollectionEquality().equals(other.suites, suites) &&
-            (identical(other.timestamp, timestamp) ||
-                other.timestamp == timestamp));
+            (identical(other.timestamp, timestamp) || other.timestamp == timestamp));
   }
 
   @override
-  int get hashCode => Object.hash(
-    runtimeType,
-    const DeepCollectionEquality().hash(suites),
-    timestamp,
-  );
+  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(suites), timestamp);
 
   /// Create a copy of Report
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$ReportImplCopyWith<_$ReportImpl> get copyWith =>
-      __$$ReportImplCopyWithImpl<_$ReportImpl>(this, _$identity);
+  _$$ReportImplCopyWith<_$ReportImpl> get copyWith => __$$ReportImplCopyWithImpl<_$ReportImpl>(this, _$identity);
 }
 
 abstract class _Report implements Report {
-  factory _Report({
-    required final Iterable<Suite> suites,
-    final DateTime? timestamp,
-  }) = _$ReportImpl;
+  factory _Report({required final Iterable<Suite> suites, final DateTime? timestamp}) = _$ReportImpl;
 
   /// The Suites in this report
   @override
@@ -174,6 +157,5 @@ abstract class _Report implements Report {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$ReportImplCopyWith<_$ReportImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$ReportImplCopyWith<_$ReportImpl> get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/processing/models/report.freezed.dart
+++ b/lib/src/processing/models/report.freezed.dart
@@ -31,13 +31,15 @@ mixin _$Report {
 
 /// @nodoc
 abstract class $ReportCopyWith<$Res> {
-  factory $ReportCopyWith(Report value, $Res Function(Report) then) = _$ReportCopyWithImpl<$Res, Report>;
+  factory $ReportCopyWith(Report value, $Res Function(Report) then) =
+      _$ReportCopyWithImpl<$Res, Report>;
   @useResult
   $Res call({Iterable<Suite> suites, DateTime? timestamp});
 }
 
 /// @nodoc
-class _$ReportCopyWithImpl<$Res, $Val extends Report> implements $ReportCopyWith<$Res> {
+class _$ReportCopyWithImpl<$Res, $Val extends Report>
+    implements $ReportCopyWith<$Res> {
   _$ReportCopyWithImpl(this._value, this._then);
 
   // ignore: unused_field
@@ -70,17 +72,23 @@ class _$ReportCopyWithImpl<$Res, $Val extends Report> implements $ReportCopyWith
 
 /// @nodoc
 abstract class _$$ReportImplCopyWith<$Res> implements $ReportCopyWith<$Res> {
-  factory _$$ReportImplCopyWith(_$ReportImpl value, $Res Function(_$ReportImpl) then) =
-      __$$ReportImplCopyWithImpl<$Res>;
+  factory _$$ReportImplCopyWith(
+    _$ReportImpl value,
+    $Res Function(_$ReportImpl) then,
+  ) = __$$ReportImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({Iterable<Suite> suites, DateTime? timestamp});
 }
 
 /// @nodoc
-class __$$ReportImplCopyWithImpl<$Res> extends _$ReportCopyWithImpl<$Res, _$ReportImpl>
+class __$$ReportImplCopyWithImpl<$Res>
+    extends _$ReportCopyWithImpl<$Res, _$ReportImpl>
     implements _$$ReportImplCopyWith<$Res> {
-  __$$ReportImplCopyWithImpl(_$ReportImpl _value, $Res Function(_$ReportImpl) _then) : super(_value, _then);
+  __$$ReportImplCopyWithImpl(
+    _$ReportImpl _value,
+    $Res Function(_$ReportImpl) _then,
+  ) : super(_value, _then);
 
   /// Create a copy of Report
   /// with the given fields replaced by the non-null parameter values.
@@ -128,22 +136,31 @@ class _$ReportImpl implements _Report {
         (other.runtimeType == runtimeType &&
             other is _$ReportImpl &&
             const DeepCollectionEquality().equals(other.suites, suites) &&
-            (identical(other.timestamp, timestamp) || other.timestamp == timestamp));
+            (identical(other.timestamp, timestamp) ||
+                other.timestamp == timestamp));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(suites), timestamp);
+  int get hashCode => Object.hash(
+    runtimeType,
+    const DeepCollectionEquality().hash(suites),
+    timestamp,
+  );
 
   /// Create a copy of Report
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$ReportImplCopyWith<_$ReportImpl> get copyWith => __$$ReportImplCopyWithImpl<_$ReportImpl>(this, _$identity);
+  _$$ReportImplCopyWith<_$ReportImpl> get copyWith =>
+      __$$ReportImplCopyWithImpl<_$ReportImpl>(this, _$identity);
 }
 
 abstract class _Report implements Report {
-  factory _Report({required final Iterable<Suite> suites, final DateTime? timestamp}) = _$ReportImpl;
+  factory _Report({
+    required final Iterable<Suite> suites,
+    final DateTime? timestamp,
+  }) = _$ReportImpl;
 
   /// The Suites in this report
   @override
@@ -157,5 +174,6 @@ abstract class _Report implements Report {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$ReportImplCopyWith<_$ReportImpl> get copyWith => throw _privateConstructorUsedError;
+  _$$ReportImplCopyWith<_$ReportImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }

--- a/lib/src/processing/models/suite.dart
+++ b/lib/src/processing/models/suite.dart
@@ -28,10 +28,14 @@ class Suite with _$Suite {
   List<Test> get tests => allTests.where((test) => !test.hidden).toList();
 
   /// All non-hidden skipped Tests
-  List<Test> get skipped => allTests.where((test) => test.skipped && !test.hidden).toList();
+  List<Test> get skipped =>
+      allTests.where((test) => test.skipped && !test.hidden).toList();
 
   /// All non-hidden Tests with problems
-  List<Test> get problems => allTests.where((test) => !test.hidden && test.problems.isNotEmpty).toList();
+  List<Test> get problems =>
+      allTests
+          .where((test) => !test.hidden && test.problems.isNotEmpty)
+          .toList();
 
   /// All hidden Tests
   List<Test> get hidden => allTests.where((test) => test.hidden).toList();

--- a/lib/src/processing/models/suite.dart
+++ b/lib/src/processing/models/suite.dart
@@ -28,13 +28,10 @@ class Suite with _$Suite {
   List<Test> get tests => allTests.where((test) => !test.hidden).toList();
 
   /// All non-hidden skipped Tests
-  List<Test> get skipped =>
-      allTests.where((test) => test.skipped && !test.hidden).toList();
+  List<Test> get skipped => allTests.where((test) => test.skipped && !test.hidden).toList();
 
   /// All non-hidden Tests with problems
-  List<Test> get problems => allTests
-      .where((test) => !test.hidden && test.problems.isNotEmpty)
-      .toList();
+  List<Test> get problems => allTests.where((test) => !test.hidden && test.problems.isNotEmpty).toList();
 
   /// All hidden Tests
   List<Test> get hidden => allTests.where((test) => test.hidden).toList();

--- a/lib/src/processing/models/suite.freezed.dart
+++ b/lib/src/processing/models/suite.freezed.dart
@@ -34,15 +34,13 @@ mixin _$Suite {
 
 /// @nodoc
 abstract class $SuiteCopyWith<$Res> {
-  factory $SuiteCopyWith(Suite value, $Res Function(Suite) then) =
-      _$SuiteCopyWithImpl<$Res, Suite>;
+  factory $SuiteCopyWith(Suite value, $Res Function(Suite) then) = _$SuiteCopyWithImpl<$Res, Suite>;
   @useResult
   $Res call({String? path, String platform, List<Test> allTests});
 }
 
 /// @nodoc
-class _$SuiteCopyWithImpl<$Res, $Val extends Suite>
-    implements $SuiteCopyWith<$Res> {
+class _$SuiteCopyWithImpl<$Res, $Val extends Suite> implements $SuiteCopyWith<$Res> {
   _$SuiteCopyWithImpl(this._value, this._then);
 
   // ignore: unused_field
@@ -54,11 +52,7 @@ class _$SuiteCopyWithImpl<$Res, $Val extends Suite>
   /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
-  $Res call({
-    Object? path = freezed,
-    Object? platform = null,
-    Object? allTests = null,
-  }) {
+  $Res call({Object? path = freezed, Object? platform = null, Object? allTests = null}) {
     return _then(
       _value.copyWith(
             path:
@@ -84,33 +78,22 @@ class _$SuiteCopyWithImpl<$Res, $Val extends Suite>
 
 /// @nodoc
 abstract class _$$SuiteImplCopyWith<$Res> implements $SuiteCopyWith<$Res> {
-  factory _$$SuiteImplCopyWith(
-    _$SuiteImpl value,
-    $Res Function(_$SuiteImpl) then,
-  ) = __$$SuiteImplCopyWithImpl<$Res>;
+  factory _$$SuiteImplCopyWith(_$SuiteImpl value, $Res Function(_$SuiteImpl) then) = __$$SuiteImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String? path, String platform, List<Test> allTests});
 }
 
 /// @nodoc
-class __$$SuiteImplCopyWithImpl<$Res>
-    extends _$SuiteCopyWithImpl<$Res, _$SuiteImpl>
+class __$$SuiteImplCopyWithImpl<$Res> extends _$SuiteCopyWithImpl<$Res, _$SuiteImpl>
     implements _$$SuiteImplCopyWith<$Res> {
-  __$$SuiteImplCopyWithImpl(
-    _$SuiteImpl _value,
-    $Res Function(_$SuiteImpl) _then,
-  ) : super(_value, _then);
+  __$$SuiteImplCopyWithImpl(_$SuiteImpl _value, $Res Function(_$SuiteImpl) _then) : super(_value, _then);
 
   /// Create a copy of Suite
   /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
-  $Res call({
-    Object? path = freezed,
-    Object? platform = null,
-    Object? allTests = null,
-  }) {
+  $Res call({Object? path = freezed, Object? platform = null, Object? allTests = null}) {
     return _then(
       _$SuiteImpl(
         path:
@@ -136,12 +119,9 @@ class __$$SuiteImplCopyWithImpl<$Res>
 /// @nodoc
 
 class _$SuiteImpl extends _Suite {
-  _$SuiteImpl({
-    this.path,
-    required this.platform,
-    required final List<Test> allTests,
-  }) : _allTests = allTests,
-       super._();
+  _$SuiteImpl({this.path, required this.platform, required final List<Test> allTests})
+    : _allTests = allTests,
+      super._();
 
   /// Optional path to this suite's file
   @override
@@ -173,34 +153,24 @@ class _$SuiteImpl extends _Suite {
         (other.runtimeType == runtimeType &&
             other is _$SuiteImpl &&
             (identical(other.path, path) || other.path == path) &&
-            (identical(other.platform, platform) ||
-                other.platform == platform) &&
+            (identical(other.platform, platform) || other.platform == platform) &&
             const DeepCollectionEquality().equals(other._allTests, _allTests));
   }
 
   @override
-  int get hashCode => Object.hash(
-    runtimeType,
-    path,
-    platform,
-    const DeepCollectionEquality().hash(_allTests),
-  );
+  int get hashCode => Object.hash(runtimeType, path, platform, const DeepCollectionEquality().hash(_allTests));
 
   /// Create a copy of Suite
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$SuiteImplCopyWith<_$SuiteImpl> get copyWith =>
-      __$$SuiteImplCopyWithImpl<_$SuiteImpl>(this, _$identity);
+  _$$SuiteImplCopyWith<_$SuiteImpl> get copyWith => __$$SuiteImplCopyWithImpl<_$SuiteImpl>(this, _$identity);
 }
 
 abstract class _Suite extends Suite {
-  factory _Suite({
-    final String? path,
-    required final String platform,
-    required final List<Test> allTests,
-  }) = _$SuiteImpl;
+  factory _Suite({final String? path, required final String platform, required final List<Test> allTests}) =
+      _$SuiteImpl;
   _Suite._() : super._();
 
   /// Optional path to this suite's file
@@ -219,6 +189,5 @@ abstract class _Suite extends Suite {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$SuiteImplCopyWith<_$SuiteImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$SuiteImplCopyWith<_$SuiteImpl> get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/processing/models/suite.freezed.dart
+++ b/lib/src/processing/models/suite.freezed.dart
@@ -1,7 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
-// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
 part of 'suite.dart';
 
@@ -12,7 +12,7 @@ part of 'suite.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods',
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
 );
 
 /// @nodoc
@@ -26,78 +26,105 @@ mixin _$Suite {
   /// All Tests contained within this suite
   List<Test> get allTests => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Suite
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $SuiteCopyWith<Suite> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class $SuiteCopyWith<$Res> {
-  factory $SuiteCopyWith(Suite value, $Res Function(Suite) then) = _$SuiteCopyWithImpl<$Res>;
+  factory $SuiteCopyWith(Suite value, $Res Function(Suite) then) =
+      _$SuiteCopyWithImpl<$Res, Suite>;
+  @useResult
   $Res call({String? path, String platform, List<Test> allTests});
 }
 
 /// @nodoc
-class _$SuiteCopyWithImpl<$Res> implements $SuiteCopyWith<$Res> {
+class _$SuiteCopyWithImpl<$Res, $Val extends Suite>
+    implements $SuiteCopyWith<$Res> {
   _$SuiteCopyWithImpl(this._value, this._then);
 
-  final Suite _value;
   // ignore: unused_field
-  final $Res Function(Suite) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  /// Create a copy of Suite
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
   @override
-  $Res call({Object? path = freezed, Object? platform = freezed, Object? allTests = freezed}) {
+  $Res call({
+    Object? path = freezed,
+    Object? platform = null,
+    Object? allTests = null,
+  }) {
     return _then(
       _value.copyWith(
-        path:
-            path == freezed
-                ? _value.path
-                : path // ignore: cast_nullable_to_non_nullable
-                    as String?,
-        platform:
-            platform == freezed
-                ? _value.platform
-                : platform // ignore: cast_nullable_to_non_nullable
-                    as String,
-        allTests:
-            allTests == freezed
-                ? _value.allTests
-                : allTests // ignore: cast_nullable_to_non_nullable
-                    as List<Test>,
-      ),
+            path:
+                freezed == path
+                    ? _value.path
+                    : path // ignore: cast_nullable_to_non_nullable
+                        as String?,
+            platform:
+                null == platform
+                    ? _value.platform
+                    : platform // ignore: cast_nullable_to_non_nullable
+                        as String,
+            allTests:
+                null == allTests
+                    ? _value.allTests
+                    : allTests // ignore: cast_nullable_to_non_nullable
+                        as List<Test>,
+          )
+          as $Val,
     );
   }
 }
 
 /// @nodoc
-abstract class _$$_SuiteCopyWith<$Res> implements $SuiteCopyWith<$Res> {
-  factory _$$_SuiteCopyWith(_$_Suite value, $Res Function(_$_Suite) then) = __$$_SuiteCopyWithImpl<$Res>;
+abstract class _$$SuiteImplCopyWith<$Res> implements $SuiteCopyWith<$Res> {
+  factory _$$SuiteImplCopyWith(
+    _$SuiteImpl value,
+    $Res Function(_$SuiteImpl) then,
+  ) = __$$SuiteImplCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call({String? path, String platform, List<Test> allTests});
 }
 
 /// @nodoc
-class __$$_SuiteCopyWithImpl<$Res> extends _$SuiteCopyWithImpl<$Res> implements _$$_SuiteCopyWith<$Res> {
-  __$$_SuiteCopyWithImpl(_$_Suite _value, $Res Function(_$_Suite) _then) : super(_value, (v) => _then(v as _$_Suite));
+class __$$SuiteImplCopyWithImpl<$Res>
+    extends _$SuiteCopyWithImpl<$Res, _$SuiteImpl>
+    implements _$$SuiteImplCopyWith<$Res> {
+  __$$SuiteImplCopyWithImpl(
+    _$SuiteImpl _value,
+    $Res Function(_$SuiteImpl) _then,
+  ) : super(_value, _then);
 
+  /// Create a copy of Suite
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
   @override
-  _$_Suite get _value => super._value as _$_Suite;
-
-  @override
-  $Res call({Object? path = freezed, Object? platform = freezed, Object? allTests = freezed}) {
+  $Res call({
+    Object? path = freezed,
+    Object? platform = null,
+    Object? allTests = null,
+  }) {
     return _then(
-      _$_Suite(
+      _$SuiteImpl(
         path:
-            path == freezed
+            freezed == path
                 ? _value.path
                 : path // ignore: cast_nullable_to_non_nullable
                     as String?,
         platform:
-            platform == freezed
+            null == platform
                 ? _value.platform
                 : platform // ignore: cast_nullable_to_non_nullable
                     as String,
         allTests:
-            allTests == freezed
+            null == allTests
                 ? _value._allTests
                 : allTests // ignore: cast_nullable_to_non_nullable
                     as List<Test>,
@@ -108,8 +135,13 @@ class __$$_SuiteCopyWithImpl<$Res> extends _$SuiteCopyWithImpl<$Res> implements 
 
 /// @nodoc
 
-class _$_Suite extends _Suite {
-  _$_Suite({this.path, required this.platform, required final List<Test> allTests}) : _allTests = allTests, super._();
+class _$SuiteImpl extends _Suite {
+  _$SuiteImpl({
+    this.path,
+    required this.platform,
+    required final List<Test> allTests,
+  }) : _allTests = allTests,
+       super._();
 
   /// Optional path to this suite's file
   @override
@@ -125,6 +157,7 @@ class _$_Suite extends _Suite {
   /// All Tests contained within this suite
   @override
   List<Test> get allTests {
+    if (_allTests is EqualUnmodifiableListView) return _allTests;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_allTests);
   }
@@ -135,42 +168,57 @@ class _$_Suite extends _Suite {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Suite &&
-            const DeepCollectionEquality().equals(other.path, path) &&
-            const DeepCollectionEquality().equals(other.platform, platform) &&
+            other is _$SuiteImpl &&
+            (identical(other.path, path) || other.path == path) &&
+            (identical(other.platform, platform) ||
+                other.platform == platform) &&
             const DeepCollectionEquality().equals(other._allTests, _allTests));
   }
 
   @override
   int get hashCode => Object.hash(
     runtimeType,
-    const DeepCollectionEquality().hash(path),
-    const DeepCollectionEquality().hash(platform),
+    path,
+    platform,
     const DeepCollectionEquality().hash(_allTests),
   );
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Suite
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  _$$_SuiteCopyWith<_$_Suite> get copyWith => __$$_SuiteCopyWithImpl<_$_Suite>(this, _$identity);
+  @pragma('vm:prefer-inline')
+  _$$SuiteImplCopyWith<_$SuiteImpl> get copyWith =>
+      __$$SuiteImplCopyWithImpl<_$SuiteImpl>(this, _$identity);
 }
 
 abstract class _Suite extends Suite {
-  factory _Suite({final String? path, required final String platform, required final List<Test> allTests}) = _$_Suite;
+  factory _Suite({
+    final String? path,
+    required final String platform,
+    required final List<Test> allTests,
+  }) = _$SuiteImpl;
   _Suite._() : super._();
 
-  @override
   /// Optional path to this suite's file
+  @override
   String? get path;
-  @override
+
   /// Platform on which this suite is running
+  @override
   String get platform;
-  @override
+
   /// All Tests contained within this suite
-  List<Test> get allTests;
   @override
-  @JsonKey(ignore: true)
-  _$$_SuiteCopyWith<_$_Suite> get copyWith => throw _privateConstructorUsedError;
+  List<Test> get allTests;
+
+  /// Create a copy of Suite
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$SuiteImplCopyWith<_$SuiteImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }

--- a/lib/src/processing/models/suite.freezed.dart
+++ b/lib/src/processing/models/suite.freezed.dart
@@ -34,13 +34,15 @@ mixin _$Suite {
 
 /// @nodoc
 abstract class $SuiteCopyWith<$Res> {
-  factory $SuiteCopyWith(Suite value, $Res Function(Suite) then) = _$SuiteCopyWithImpl<$Res, Suite>;
+  factory $SuiteCopyWith(Suite value, $Res Function(Suite) then) =
+      _$SuiteCopyWithImpl<$Res, Suite>;
   @useResult
   $Res call({String? path, String platform, List<Test> allTests});
 }
 
 /// @nodoc
-class _$SuiteCopyWithImpl<$Res, $Val extends Suite> implements $SuiteCopyWith<$Res> {
+class _$SuiteCopyWithImpl<$Res, $Val extends Suite>
+    implements $SuiteCopyWith<$Res> {
   _$SuiteCopyWithImpl(this._value, this._then);
 
   // ignore: unused_field
@@ -52,7 +54,11 @@ class _$SuiteCopyWithImpl<$Res, $Val extends Suite> implements $SuiteCopyWith<$R
   /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
-  $Res call({Object? path = freezed, Object? platform = null, Object? allTests = null}) {
+  $Res call({
+    Object? path = freezed,
+    Object? platform = null,
+    Object? allTests = null,
+  }) {
     return _then(
       _value.copyWith(
             path:
@@ -78,22 +84,33 @@ class _$SuiteCopyWithImpl<$Res, $Val extends Suite> implements $SuiteCopyWith<$R
 
 /// @nodoc
 abstract class _$$SuiteImplCopyWith<$Res> implements $SuiteCopyWith<$Res> {
-  factory _$$SuiteImplCopyWith(_$SuiteImpl value, $Res Function(_$SuiteImpl) then) = __$$SuiteImplCopyWithImpl<$Res>;
+  factory _$$SuiteImplCopyWith(
+    _$SuiteImpl value,
+    $Res Function(_$SuiteImpl) then,
+  ) = __$$SuiteImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String? path, String platform, List<Test> allTests});
 }
 
 /// @nodoc
-class __$$SuiteImplCopyWithImpl<$Res> extends _$SuiteCopyWithImpl<$Res, _$SuiteImpl>
+class __$$SuiteImplCopyWithImpl<$Res>
+    extends _$SuiteCopyWithImpl<$Res, _$SuiteImpl>
     implements _$$SuiteImplCopyWith<$Res> {
-  __$$SuiteImplCopyWithImpl(_$SuiteImpl _value, $Res Function(_$SuiteImpl) _then) : super(_value, _then);
+  __$$SuiteImplCopyWithImpl(
+    _$SuiteImpl _value,
+    $Res Function(_$SuiteImpl) _then,
+  ) : super(_value, _then);
 
   /// Create a copy of Suite
   /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
-  $Res call({Object? path = freezed, Object? platform = null, Object? allTests = null}) {
+  $Res call({
+    Object? path = freezed,
+    Object? platform = null,
+    Object? allTests = null,
+  }) {
     return _then(
       _$SuiteImpl(
         path:
@@ -119,9 +136,12 @@ class __$$SuiteImplCopyWithImpl<$Res> extends _$SuiteCopyWithImpl<$Res, _$SuiteI
 /// @nodoc
 
 class _$SuiteImpl extends _Suite {
-  _$SuiteImpl({this.path, required this.platform, required final List<Test> allTests})
-    : _allTests = allTests,
-      super._();
+  _$SuiteImpl({
+    this.path,
+    required this.platform,
+    required final List<Test> allTests,
+  }) : _allTests = allTests,
+       super._();
 
   /// Optional path to this suite's file
   @override
@@ -153,24 +173,34 @@ class _$SuiteImpl extends _Suite {
         (other.runtimeType == runtimeType &&
             other is _$SuiteImpl &&
             (identical(other.path, path) || other.path == path) &&
-            (identical(other.platform, platform) || other.platform == platform) &&
+            (identical(other.platform, platform) ||
+                other.platform == platform) &&
             const DeepCollectionEquality().equals(other._allTests, _allTests));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, path, platform, const DeepCollectionEquality().hash(_allTests));
+  int get hashCode => Object.hash(
+    runtimeType,
+    path,
+    platform,
+    const DeepCollectionEquality().hash(_allTests),
+  );
 
   /// Create a copy of Suite
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$SuiteImplCopyWith<_$SuiteImpl> get copyWith => __$$SuiteImplCopyWithImpl<_$SuiteImpl>(this, _$identity);
+  _$$SuiteImplCopyWith<_$SuiteImpl> get copyWith =>
+      __$$SuiteImplCopyWithImpl<_$SuiteImpl>(this, _$identity);
 }
 
 abstract class _Suite extends Suite {
-  factory _Suite({final String? path, required final String platform, required final List<Test> allTests}) =
-      _$SuiteImpl;
+  factory _Suite({
+    final String? path,
+    required final String platform,
+    required final List<Test> allTests,
+  }) = _$SuiteImpl;
   _Suite._() : super._();
 
   /// Optional path to this suite's file
@@ -189,5 +219,6 @@ abstract class _Suite extends Suite {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$SuiteImplCopyWith<_$SuiteImpl> get copyWith => throw _privateConstructorUsedError;
+  _$$SuiteImplCopyWith<_$SuiteImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }

--- a/lib/src/processing/models/suite.freezed.dart
+++ b/lib/src/processing/models/suite.freezed.dart
@@ -12,7 +12,8 @@ part of 'suite.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods',
+);
 
 /// @nodoc
 mixin _$Suite {
@@ -31,8 +32,7 @@ mixin _$Suite {
 
 /// @nodoc
 abstract class $SuiteCopyWith<$Res> {
-  factory $SuiteCopyWith(Suite value, $Res Function(Suite) then) =
-      _$SuiteCopyWithImpl<$Res>;
+  factory $SuiteCopyWith(Suite value, $Res Function(Suite) then) = _$SuiteCopyWithImpl<$Res>;
   $Res call({String? path, String platform, List<Test> allTests});
 }
 
@@ -45,75 +45,71 @@ class _$SuiteCopyWithImpl<$Res> implements $SuiteCopyWith<$Res> {
   final $Res Function(Suite) _then;
 
   @override
-  $Res call({
-    Object? path = freezed,
-    Object? platform = freezed,
-    Object? allTests = freezed,
-  }) {
-    return _then(_value.copyWith(
-      path: path == freezed
-          ? _value.path
-          : path // ignore: cast_nullable_to_non_nullable
-              as String?,
-      platform: platform == freezed
-          ? _value.platform
-          : platform // ignore: cast_nullable_to_non_nullable
-              as String,
-      allTests: allTests == freezed
-          ? _value.allTests
-          : allTests // ignore: cast_nullable_to_non_nullable
-              as List<Test>,
-    ));
+  $Res call({Object? path = freezed, Object? platform = freezed, Object? allTests = freezed}) {
+    return _then(
+      _value.copyWith(
+        path:
+            path == freezed
+                ? _value.path
+                : path // ignore: cast_nullable_to_non_nullable
+                    as String?,
+        platform:
+            platform == freezed
+                ? _value.platform
+                : platform // ignore: cast_nullable_to_non_nullable
+                    as String,
+        allTests:
+            allTests == freezed
+                ? _value.allTests
+                : allTests // ignore: cast_nullable_to_non_nullable
+                    as List<Test>,
+      ),
+    );
   }
 }
 
 /// @nodoc
 abstract class _$$_SuiteCopyWith<$Res> implements $SuiteCopyWith<$Res> {
-  factory _$$_SuiteCopyWith(_$_Suite value, $Res Function(_$_Suite) then) =
-      __$$_SuiteCopyWithImpl<$Res>;
+  factory _$$_SuiteCopyWith(_$_Suite value, $Res Function(_$_Suite) then) = __$$_SuiteCopyWithImpl<$Res>;
   @override
   $Res call({String? path, String platform, List<Test> allTests});
 }
 
 /// @nodoc
-class __$$_SuiteCopyWithImpl<$Res> extends _$SuiteCopyWithImpl<$Res>
-    implements _$$_SuiteCopyWith<$Res> {
-  __$$_SuiteCopyWithImpl(_$_Suite _value, $Res Function(_$_Suite) _then)
-      : super(_value, (v) => _then(v as _$_Suite));
+class __$$_SuiteCopyWithImpl<$Res> extends _$SuiteCopyWithImpl<$Res> implements _$$_SuiteCopyWith<$Res> {
+  __$$_SuiteCopyWithImpl(_$_Suite _value, $Res Function(_$_Suite) _then) : super(_value, (v) => _then(v as _$_Suite));
 
   @override
   _$_Suite get _value => super._value as _$_Suite;
 
   @override
-  $Res call({
-    Object? path = freezed,
-    Object? platform = freezed,
-    Object? allTests = freezed,
-  }) {
-    return _then(_$_Suite(
-      path: path == freezed
-          ? _value.path
-          : path // ignore: cast_nullable_to_non_nullable
-              as String?,
-      platform: platform == freezed
-          ? _value.platform
-          : platform // ignore: cast_nullable_to_non_nullable
-              as String,
-      allTests: allTests == freezed
-          ? _value._allTests
-          : allTests // ignore: cast_nullable_to_non_nullable
-              as List<Test>,
-    ));
+  $Res call({Object? path = freezed, Object? platform = freezed, Object? allTests = freezed}) {
+    return _then(
+      _$_Suite(
+        path:
+            path == freezed
+                ? _value.path
+                : path // ignore: cast_nullable_to_non_nullable
+                    as String?,
+        platform:
+            platform == freezed
+                ? _value.platform
+                : platform // ignore: cast_nullable_to_non_nullable
+                    as String,
+        allTests:
+            allTests == freezed
+                ? _value._allTests
+                : allTests // ignore: cast_nullable_to_non_nullable
+                    as List<Test>,
+      ),
+    );
   }
 }
 
 /// @nodoc
 
 class _$_Suite extends _Suite {
-  _$_Suite(
-      {this.path, required this.platform, required final List<Test> allTests})
-      : _allTests = allTests,
-        super._();
+  _$_Suite({this.path, required this.platform, required final List<Test> allTests}) : _allTests = allTests, super._();
 
   /// Optional path to this suite's file
   @override
@@ -150,38 +146,31 @@ class _$_Suite extends _Suite {
 
   @override
   int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(path),
-      const DeepCollectionEquality().hash(platform),
-      const DeepCollectionEquality().hash(_allTests));
+    runtimeType,
+    const DeepCollectionEquality().hash(path),
+    const DeepCollectionEquality().hash(platform),
+    const DeepCollectionEquality().hash(_allTests),
+  );
 
   @JsonKey(ignore: true)
   @override
-  _$$_SuiteCopyWith<_$_Suite> get copyWith =>
-      __$$_SuiteCopyWithImpl<_$_Suite>(this, _$identity);
+  _$$_SuiteCopyWith<_$_Suite> get copyWith => __$$_SuiteCopyWithImpl<_$_Suite>(this, _$identity);
 }
 
 abstract class _Suite extends Suite {
-  factory _Suite(
-      {final String? path,
-      required final String platform,
-      required final List<Test> allTests}) = _$_Suite;
+  factory _Suite({final String? path, required final String platform, required final List<Test> allTests}) = _$_Suite;
   _Suite._() : super._();
 
   @override
-
   /// Optional path to this suite's file
   String? get path;
   @override
-
   /// Platform on which this suite is running
   String get platform;
   @override
-
   /// All Tests contained within this suite
   List<Test> get allTests;
   @override
   @JsonKey(ignore: true)
-  _$$_SuiteCopyWith<_$_Suite> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$_SuiteCopyWith<_$_Suite> get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/processing/models/test.freezed.dart
+++ b/lib/src/processing/models/test.freezed.dart
@@ -59,7 +59,8 @@ mixin _$Test {
 
 /// @nodoc
 abstract class $TestCopyWith<$Res> {
-  factory $TestCopyWith(Test value, $Res Function(Test) then) = _$TestCopyWithImpl<$Res, Test>;
+  factory $TestCopyWith(Test value, $Res Function(Test) then) =
+      _$TestCopyWithImpl<$Res, Test>;
   @useResult
   $Res call({
     int suiteId,
@@ -76,7 +77,8 @@ abstract class $TestCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$TestCopyWithImpl<$Res, $Val extends Test> implements $TestCopyWith<$Res> {
+class _$TestCopyWithImpl<$Res, $Val extends Test>
+    implements $TestCopyWith<$Res> {
   _$TestCopyWithImpl(this._value, this._then);
 
   // ignore: unused_field
@@ -160,7 +162,10 @@ class _$TestCopyWithImpl<$Res, $Val extends Test> implements $TestCopyWith<$Res>
 
 /// @nodoc
 abstract class _$$TestImplCopyWith<$Res> implements $TestCopyWith<$Res> {
-  factory _$$TestImplCopyWith(_$TestImpl value, $Res Function(_$TestImpl) then) = __$$TestImplCopyWithImpl<$Res>;
+  factory _$$TestImplCopyWith(
+    _$TestImpl value,
+    $Res Function(_$TestImpl) then,
+  ) = __$$TestImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({
@@ -178,8 +183,11 @@ abstract class _$$TestImplCopyWith<$Res> implements $TestCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$TestImplCopyWithImpl<$Res> extends _$TestCopyWithImpl<$Res, _$TestImpl> implements _$$TestImplCopyWith<$Res> {
-  __$$TestImplCopyWithImpl(_$TestImpl _value, $Res Function(_$TestImpl) _then) : super(_value, _then);
+class __$$TestImplCopyWithImpl<$Res>
+    extends _$TestCopyWithImpl<$Res, _$TestImpl>
+    implements _$$TestImplCopyWith<$Res> {
+  __$$TestImplCopyWithImpl(_$TestImpl _value, $Res Function(_$TestImpl) _then)
+    : super(_value, _then);
 
   /// Create a copy of Test
   /// with the given fields replaced by the non-null parameter values.
@@ -345,7 +353,8 @@ class _$TestImpl extends _Test {
             other is _$TestImpl &&
             (identical(other.suiteId, suiteId) || other.suiteId == suiteId) &&
             (identical(other.name, name) || other.name == name) &&
-            (identical(other.startTime, startTime) || other.startTime == startTime) &&
+            (identical(other.startTime, startTime) ||
+                other.startTime == startTime) &&
             (identical(other.url, url) || other.url == url) &&
             (identical(other.rootUrl, rootUrl) || other.rootUrl == rootUrl) &&
             (identical(other.endTime, endTime) || other.endTime == endTime) &&
@@ -375,7 +384,8 @@ class _$TestImpl extends _Test {
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$TestImplCopyWith<_$TestImpl> get copyWith => __$$TestImplCopyWithImpl<_$TestImpl>(this, _$identity);
+  _$$TestImplCopyWith<_$TestImpl> get copyWith =>
+      __$$TestImplCopyWithImpl<_$TestImpl>(this, _$identity);
 }
 
 abstract class _Test extends Test {
@@ -441,5 +451,6 @@ abstract class _Test extends Test {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$TestImplCopyWith<_$TestImpl> get copyWith => throw _privateConstructorUsedError;
+  _$$TestImplCopyWith<_$TestImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }

--- a/lib/src/processing/models/test.freezed.dart
+++ b/lib/src/processing/models/test.freezed.dart
@@ -59,8 +59,7 @@ mixin _$Test {
 
 /// @nodoc
 abstract class $TestCopyWith<$Res> {
-  factory $TestCopyWith(Test value, $Res Function(Test) then) =
-      _$TestCopyWithImpl<$Res, Test>;
+  factory $TestCopyWith(Test value, $Res Function(Test) then) = _$TestCopyWithImpl<$Res, Test>;
   @useResult
   $Res call({
     int suiteId,
@@ -77,8 +76,7 @@ abstract class $TestCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$TestCopyWithImpl<$Res, $Val extends Test>
-    implements $TestCopyWith<$Res> {
+class _$TestCopyWithImpl<$Res, $Val extends Test> implements $TestCopyWith<$Res> {
   _$TestCopyWithImpl(this._value, this._then);
 
   // ignore: unused_field
@@ -162,10 +160,7 @@ class _$TestCopyWithImpl<$Res, $Val extends Test>
 
 /// @nodoc
 abstract class _$$TestImplCopyWith<$Res> implements $TestCopyWith<$Res> {
-  factory _$$TestImplCopyWith(
-    _$TestImpl value,
-    $Res Function(_$TestImpl) then,
-  ) = __$$TestImplCopyWithImpl<$Res>;
+  factory _$$TestImplCopyWith(_$TestImpl value, $Res Function(_$TestImpl) then) = __$$TestImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({
@@ -183,11 +178,8 @@ abstract class _$$TestImplCopyWith<$Res> implements $TestCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$TestImplCopyWithImpl<$Res>
-    extends _$TestCopyWithImpl<$Res, _$TestImpl>
-    implements _$$TestImplCopyWith<$Res> {
-  __$$TestImplCopyWithImpl(_$TestImpl _value, $Res Function(_$TestImpl) _then)
-    : super(_value, _then);
+class __$$TestImplCopyWithImpl<$Res> extends _$TestCopyWithImpl<$Res, _$TestImpl> implements _$$TestImplCopyWith<$Res> {
+  __$$TestImplCopyWithImpl(_$TestImpl _value, $Res Function(_$TestImpl) _then) : super(_value, _then);
 
   /// Create a copy of Test
   /// with the given fields replaced by the non-null parameter values.
@@ -353,8 +345,7 @@ class _$TestImpl extends _Test {
             other is _$TestImpl &&
             (identical(other.suiteId, suiteId) || other.suiteId == suiteId) &&
             (identical(other.name, name) || other.name == name) &&
-            (identical(other.startTime, startTime) ||
-                other.startTime == startTime) &&
+            (identical(other.startTime, startTime) || other.startTime == startTime) &&
             (identical(other.url, url) || other.url == url) &&
             (identical(other.rootUrl, rootUrl) || other.rootUrl == rootUrl) &&
             (identical(other.endTime, endTime) || other.endTime == endTime) &&
@@ -384,8 +375,7 @@ class _$TestImpl extends _Test {
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$TestImplCopyWith<_$TestImpl> get copyWith =>
-      __$$TestImplCopyWithImpl<_$TestImpl>(this, _$identity);
+  _$$TestImplCopyWith<_$TestImpl> get copyWith => __$$TestImplCopyWithImpl<_$TestImpl>(this, _$identity);
 }
 
 abstract class _Test extends Test {
@@ -451,6 +441,5 @@ abstract class _Test extends Test {
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$TestImplCopyWith<_$TestImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$TestImplCopyWith<_$TestImpl> get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/processing/models/test.freezed.dart
+++ b/lib/src/processing/models/test.freezed.dart
@@ -12,7 +12,8 @@ part of 'test.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods',
+);
 
 /// @nodoc
 mixin _$Test {
@@ -56,19 +57,19 @@ mixin _$Test {
 
 /// @nodoc
 abstract class $TestCopyWith<$Res> {
-  factory $TestCopyWith(Test value, $Res Function(Test) then) =
-      _$TestCopyWithImpl<$Res>;
-  $Res call(
-      {int suiteId,
-      String name,
-      int startTime,
-      String? url,
-      String? rootUrl,
-      int endTime,
-      bool hidden,
-      bool skipped,
-      List<Problem> problems,
-      List<String> prints});
+  factory $TestCopyWith(Test value, $Res Function(Test) then) = _$TestCopyWithImpl<$Res>;
+  $Res call({
+    int suiteId,
+    String name,
+    int startTime,
+    String? url,
+    String? rootUrl,
+    int endTime,
+    bool hidden,
+    bool skipped,
+    List<Problem> problems,
+    List<String> prints,
+  });
 }
 
 /// @nodoc
@@ -92,74 +93,84 @@ class _$TestCopyWithImpl<$Res> implements $TestCopyWith<$Res> {
     Object? problems = freezed,
     Object? prints = freezed,
   }) {
-    return _then(_value.copyWith(
-      suiteId: suiteId == freezed
-          ? _value.suiteId
-          : suiteId // ignore: cast_nullable_to_non_nullable
-              as int,
-      name: name == freezed
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      startTime: startTime == freezed
-          ? _value.startTime
-          : startTime // ignore: cast_nullable_to_non_nullable
-              as int,
-      url: url == freezed
-          ? _value.url
-          : url // ignore: cast_nullable_to_non_nullable
-              as String?,
-      rootUrl: rootUrl == freezed
-          ? _value.rootUrl
-          : rootUrl // ignore: cast_nullable_to_non_nullable
-              as String?,
-      endTime: endTime == freezed
-          ? _value.endTime
-          : endTime // ignore: cast_nullable_to_non_nullable
-              as int,
-      hidden: hidden == freezed
-          ? _value.hidden
-          : hidden // ignore: cast_nullable_to_non_nullable
-              as bool,
-      skipped: skipped == freezed
-          ? _value.skipped
-          : skipped // ignore: cast_nullable_to_non_nullable
-              as bool,
-      problems: problems == freezed
-          ? _value.problems
-          : problems // ignore: cast_nullable_to_non_nullable
-              as List<Problem>,
-      prints: prints == freezed
-          ? _value.prints
-          : prints // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-    ));
+    return _then(
+      _value.copyWith(
+        suiteId:
+            suiteId == freezed
+                ? _value.suiteId
+                : suiteId // ignore: cast_nullable_to_non_nullable
+                    as int,
+        name:
+            name == freezed
+                ? _value.name
+                : name // ignore: cast_nullable_to_non_nullable
+                    as String,
+        startTime:
+            startTime == freezed
+                ? _value.startTime
+                : startTime // ignore: cast_nullable_to_non_nullable
+                    as int,
+        url:
+            url == freezed
+                ? _value.url
+                : url // ignore: cast_nullable_to_non_nullable
+                    as String?,
+        rootUrl:
+            rootUrl == freezed
+                ? _value.rootUrl
+                : rootUrl // ignore: cast_nullable_to_non_nullable
+                    as String?,
+        endTime:
+            endTime == freezed
+                ? _value.endTime
+                : endTime // ignore: cast_nullable_to_non_nullable
+                    as int,
+        hidden:
+            hidden == freezed
+                ? _value.hidden
+                : hidden // ignore: cast_nullable_to_non_nullable
+                    as bool,
+        skipped:
+            skipped == freezed
+                ? _value.skipped
+                : skipped // ignore: cast_nullable_to_non_nullable
+                    as bool,
+        problems:
+            problems == freezed
+                ? _value.problems
+                : problems // ignore: cast_nullable_to_non_nullable
+                    as List<Problem>,
+        prints:
+            prints == freezed
+                ? _value.prints
+                : prints // ignore: cast_nullable_to_non_nullable
+                    as List<String>,
+      ),
+    );
   }
 }
 
 /// @nodoc
 abstract class _$$_TestCopyWith<$Res> implements $TestCopyWith<$Res> {
-  factory _$$_TestCopyWith(_$_Test value, $Res Function(_$_Test) then) =
-      __$$_TestCopyWithImpl<$Res>;
+  factory _$$_TestCopyWith(_$_Test value, $Res Function(_$_Test) then) = __$$_TestCopyWithImpl<$Res>;
   @override
-  $Res call(
-      {int suiteId,
-      String name,
-      int startTime,
-      String? url,
-      String? rootUrl,
-      int endTime,
-      bool hidden,
-      bool skipped,
-      List<Problem> problems,
-      List<String> prints});
+  $Res call({
+    int suiteId,
+    String name,
+    int startTime,
+    String? url,
+    String? rootUrl,
+    int endTime,
+    bool hidden,
+    bool skipped,
+    List<Problem> problems,
+    List<String> prints,
+  });
 }
 
 /// @nodoc
-class __$$_TestCopyWithImpl<$Res> extends _$TestCopyWithImpl<$Res>
-    implements _$$_TestCopyWith<$Res> {
-  __$$_TestCopyWithImpl(_$_Test _value, $Res Function(_$_Test) _then)
-      : super(_value, (v) => _then(v as _$_Test));
+class __$$_TestCopyWithImpl<$Res> extends _$TestCopyWithImpl<$Res> implements _$$_TestCopyWith<$Res> {
+  __$$_TestCopyWithImpl(_$_Test _value, $Res Function(_$_Test) _then) : super(_value, (v) => _then(v as _$_Test));
 
   @override
   _$_Test get _value => super._value as _$_Test;
@@ -177,68 +188,80 @@ class __$$_TestCopyWithImpl<$Res> extends _$TestCopyWithImpl<$Res>
     Object? problems = freezed,
     Object? prints = freezed,
   }) {
-    return _then(_$_Test(
-      suiteId: suiteId == freezed
-          ? _value.suiteId
-          : suiteId // ignore: cast_nullable_to_non_nullable
-              as int,
-      name: name == freezed
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      startTime: startTime == freezed
-          ? _value.startTime
-          : startTime // ignore: cast_nullable_to_non_nullable
-              as int,
-      url: url == freezed
-          ? _value.url
-          : url // ignore: cast_nullable_to_non_nullable
-              as String?,
-      rootUrl: rootUrl == freezed
-          ? _value.rootUrl
-          : rootUrl // ignore: cast_nullable_to_non_nullable
-              as String?,
-      endTime: endTime == freezed
-          ? _value.endTime
-          : endTime // ignore: cast_nullable_to_non_nullable
-              as int,
-      hidden: hidden == freezed
-          ? _value.hidden
-          : hidden // ignore: cast_nullable_to_non_nullable
-              as bool,
-      skipped: skipped == freezed
-          ? _value.skipped
-          : skipped // ignore: cast_nullable_to_non_nullable
-              as bool,
-      problems: problems == freezed
-          ? _value._problems
-          : problems // ignore: cast_nullable_to_non_nullable
-              as List<Problem>,
-      prints: prints == freezed
-          ? _value._prints
-          : prints // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-    ));
+    return _then(
+      _$_Test(
+        suiteId:
+            suiteId == freezed
+                ? _value.suiteId
+                : suiteId // ignore: cast_nullable_to_non_nullable
+                    as int,
+        name:
+            name == freezed
+                ? _value.name
+                : name // ignore: cast_nullable_to_non_nullable
+                    as String,
+        startTime:
+            startTime == freezed
+                ? _value.startTime
+                : startTime // ignore: cast_nullable_to_non_nullable
+                    as int,
+        url:
+            url == freezed
+                ? _value.url
+                : url // ignore: cast_nullable_to_non_nullable
+                    as String?,
+        rootUrl:
+            rootUrl == freezed
+                ? _value.rootUrl
+                : rootUrl // ignore: cast_nullable_to_non_nullable
+                    as String?,
+        endTime:
+            endTime == freezed
+                ? _value.endTime
+                : endTime // ignore: cast_nullable_to_non_nullable
+                    as int,
+        hidden:
+            hidden == freezed
+                ? _value.hidden
+                : hidden // ignore: cast_nullable_to_non_nullable
+                    as bool,
+        skipped:
+            skipped == freezed
+                ? _value.skipped
+                : skipped // ignore: cast_nullable_to_non_nullable
+                    as bool,
+        problems:
+            problems == freezed
+                ? _value._problems
+                : problems // ignore: cast_nullable_to_non_nullable
+                    as List<Problem>,
+        prints:
+            prints == freezed
+                ? _value._prints
+                : prints // ignore: cast_nullable_to_non_nullable
+                    as List<String>,
+      ),
+    );
   }
 }
 
 /// @nodoc
 
 class _$_Test extends _Test {
-  _$_Test(
-      {required this.suiteId,
-      required this.name,
-      required this.startTime,
-      this.url,
-      this.rootUrl,
-      this.endTime = -1,
-      this.hidden = false,
-      this.skipped = false,
-      required final List<Problem> problems,
-      required final List<String> prints})
-      : _problems = problems,
-        _prints = prints,
-        super._();
+  _$_Test({
+    required this.suiteId,
+    required this.name,
+    required this.startTime,
+    this.url,
+    this.rootUrl,
+    this.endTime = -1,
+    this.hidden = false,
+    this.skipped = false,
+    required final List<Problem> problems,
+    required final List<String> prints,
+  }) : _problems = problems,
+       _prints = prints,
+       super._();
 
   /// The id of the suite to which this test belongs.
   @override
@@ -323,80 +346,71 @@ class _$_Test extends _Test {
 
   @override
   int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(suiteId),
-      const DeepCollectionEquality().hash(name),
-      const DeepCollectionEquality().hash(startTime),
-      const DeepCollectionEquality().hash(url),
-      const DeepCollectionEquality().hash(rootUrl),
-      const DeepCollectionEquality().hash(endTime),
-      const DeepCollectionEquality().hash(hidden),
-      const DeepCollectionEquality().hash(skipped),
-      const DeepCollectionEquality().hash(_problems),
-      const DeepCollectionEquality().hash(_prints));
+    runtimeType,
+    const DeepCollectionEquality().hash(suiteId),
+    const DeepCollectionEquality().hash(name),
+    const DeepCollectionEquality().hash(startTime),
+    const DeepCollectionEquality().hash(url),
+    const DeepCollectionEquality().hash(rootUrl),
+    const DeepCollectionEquality().hash(endTime),
+    const DeepCollectionEquality().hash(hidden),
+    const DeepCollectionEquality().hash(skipped),
+    const DeepCollectionEquality().hash(_problems),
+    const DeepCollectionEquality().hash(_prints),
+  );
 
   @JsonKey(ignore: true)
   @override
-  _$$_TestCopyWith<_$_Test> get copyWith =>
-      __$$_TestCopyWithImpl<_$_Test>(this, _$identity);
+  _$$_TestCopyWith<_$_Test> get copyWith => __$$_TestCopyWithImpl<_$_Test>(this, _$identity);
 }
 
 abstract class _Test extends Test {
-  factory _Test(
-      {required final int suiteId,
-      required final String name,
-      required final int startTime,
-      final String? url,
-      final String? rootUrl,
-      final int endTime,
-      final bool hidden,
-      final bool skipped,
-      required final List<Problem> problems,
-      required final List<String> prints}) = _$_Test;
+  factory _Test({
+    required final int suiteId,
+    required final String name,
+    required final int startTime,
+    final String? url,
+    final String? rootUrl,
+    final int endTime,
+    final bool hidden,
+    final bool skipped,
+    required final List<Problem> problems,
+    required final List<String> prints,
+  }) = _$_Test;
   _Test._() : super._();
 
   @override
-
   /// The id of the suite to which this test belongs.
   int get suiteId;
   @override
-
   /// The name of this test, including prefixes from any containing groups.
   String get name;
   @override
-
   /// The time (in milliseconds) that has elapsed between the test runner starting and this test starting.
   int get startTime;
   @override
-
   /// Optional URL for the file in which this test was defined
   String? get url;
   @override
-
   /// Optional URL for the original test suite in which this test was defined
   ///
   /// Will only be present if different from `url`
   String? get rootUrl;
   @override
-
   /// The time (in milliseconds) that has elapsed between the test runner starting and this test completing.
   ///
   /// This will be -1 if this test was not completed.
   int get endTime;
   @override
-
   /// Whether this test's result should be hidden.
   bool get hidden;
   @override
-
   /// Whether this test (or some part of it) was skipped.
   bool get skipped;
   @override
-
   /// A list of any problems that occured during this test.
   List<Problem> get problems;
   @override
-
   /// A list of any messages emitted during this test.
   List<String> get prints;
   @override

--- a/lib/src/processing/models/test.freezed.dart
+++ b/lib/src/processing/models/test.freezed.dart
@@ -1,7 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
-// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
 part of 'test.dart';
 
@@ -12,7 +12,7 @@ part of 'test.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods',
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
 );
 
 /// @nodoc
@@ -51,13 +51,17 @@ mixin _$Test {
   /// A list of any messages emitted during this test.
   List<String> get prints => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Test
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $TestCopyWith<Test> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class $TestCopyWith<$Res> {
-  factory $TestCopyWith(Test value, $Res Function(Test) then) = _$TestCopyWithImpl<$Res>;
+  factory $TestCopyWith(Test value, $Res Function(Test) then) =
+      _$TestCopyWithImpl<$Res, Test>;
+  @useResult
   $Res call({
     int suiteId,
     String name,
@@ -73,87 +77,97 @@ abstract class $TestCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$TestCopyWithImpl<$Res> implements $TestCopyWith<$Res> {
+class _$TestCopyWithImpl<$Res, $Val extends Test>
+    implements $TestCopyWith<$Res> {
   _$TestCopyWithImpl(this._value, this._then);
 
-  final Test _value;
   // ignore: unused_field
-  final $Res Function(Test) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  /// Create a copy of Test
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? suiteId = freezed,
-    Object? name = freezed,
-    Object? startTime = freezed,
+    Object? suiteId = null,
+    Object? name = null,
+    Object? startTime = null,
     Object? url = freezed,
     Object? rootUrl = freezed,
-    Object? endTime = freezed,
-    Object? hidden = freezed,
-    Object? skipped = freezed,
-    Object? problems = freezed,
-    Object? prints = freezed,
+    Object? endTime = null,
+    Object? hidden = null,
+    Object? skipped = null,
+    Object? problems = null,
+    Object? prints = null,
   }) {
     return _then(
       _value.copyWith(
-        suiteId:
-            suiteId == freezed
-                ? _value.suiteId
-                : suiteId // ignore: cast_nullable_to_non_nullable
-                    as int,
-        name:
-            name == freezed
-                ? _value.name
-                : name // ignore: cast_nullable_to_non_nullable
-                    as String,
-        startTime:
-            startTime == freezed
-                ? _value.startTime
-                : startTime // ignore: cast_nullable_to_non_nullable
-                    as int,
-        url:
-            url == freezed
-                ? _value.url
-                : url // ignore: cast_nullable_to_non_nullable
-                    as String?,
-        rootUrl:
-            rootUrl == freezed
-                ? _value.rootUrl
-                : rootUrl // ignore: cast_nullable_to_non_nullable
-                    as String?,
-        endTime:
-            endTime == freezed
-                ? _value.endTime
-                : endTime // ignore: cast_nullable_to_non_nullable
-                    as int,
-        hidden:
-            hidden == freezed
-                ? _value.hidden
-                : hidden // ignore: cast_nullable_to_non_nullable
-                    as bool,
-        skipped:
-            skipped == freezed
-                ? _value.skipped
-                : skipped // ignore: cast_nullable_to_non_nullable
-                    as bool,
-        problems:
-            problems == freezed
-                ? _value.problems
-                : problems // ignore: cast_nullable_to_non_nullable
-                    as List<Problem>,
-        prints:
-            prints == freezed
-                ? _value.prints
-                : prints // ignore: cast_nullable_to_non_nullable
-                    as List<String>,
-      ),
+            suiteId:
+                null == suiteId
+                    ? _value.suiteId
+                    : suiteId // ignore: cast_nullable_to_non_nullable
+                        as int,
+            name:
+                null == name
+                    ? _value.name
+                    : name // ignore: cast_nullable_to_non_nullable
+                        as String,
+            startTime:
+                null == startTime
+                    ? _value.startTime
+                    : startTime // ignore: cast_nullable_to_non_nullable
+                        as int,
+            url:
+                freezed == url
+                    ? _value.url
+                    : url // ignore: cast_nullable_to_non_nullable
+                        as String?,
+            rootUrl:
+                freezed == rootUrl
+                    ? _value.rootUrl
+                    : rootUrl // ignore: cast_nullable_to_non_nullable
+                        as String?,
+            endTime:
+                null == endTime
+                    ? _value.endTime
+                    : endTime // ignore: cast_nullable_to_non_nullable
+                        as int,
+            hidden:
+                null == hidden
+                    ? _value.hidden
+                    : hidden // ignore: cast_nullable_to_non_nullable
+                        as bool,
+            skipped:
+                null == skipped
+                    ? _value.skipped
+                    : skipped // ignore: cast_nullable_to_non_nullable
+                        as bool,
+            problems:
+                null == problems
+                    ? _value.problems
+                    : problems // ignore: cast_nullable_to_non_nullable
+                        as List<Problem>,
+            prints:
+                null == prints
+                    ? _value.prints
+                    : prints // ignore: cast_nullable_to_non_nullable
+                        as List<String>,
+          )
+          as $Val,
     );
   }
 }
 
 /// @nodoc
-abstract class _$$_TestCopyWith<$Res> implements $TestCopyWith<$Res> {
-  factory _$$_TestCopyWith(_$_Test value, $Res Function(_$_Test) then) = __$$_TestCopyWithImpl<$Res>;
+abstract class _$$TestImplCopyWith<$Res> implements $TestCopyWith<$Res> {
+  factory _$$TestImplCopyWith(
+    _$TestImpl value,
+    $Res Function(_$TestImpl) then,
+  ) = __$$TestImplCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call({
     int suiteId,
     String name,
@@ -169,74 +183,77 @@ abstract class _$$_TestCopyWith<$Res> implements $TestCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_TestCopyWithImpl<$Res> extends _$TestCopyWithImpl<$Res> implements _$$_TestCopyWith<$Res> {
-  __$$_TestCopyWithImpl(_$_Test _value, $Res Function(_$_Test) _then) : super(_value, (v) => _then(v as _$_Test));
+class __$$TestImplCopyWithImpl<$Res>
+    extends _$TestCopyWithImpl<$Res, _$TestImpl>
+    implements _$$TestImplCopyWith<$Res> {
+  __$$TestImplCopyWithImpl(_$TestImpl _value, $Res Function(_$TestImpl) _then)
+    : super(_value, _then);
 
-  @override
-  _$_Test get _value => super._value as _$_Test;
-
+  /// Create a copy of Test
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? suiteId = freezed,
-    Object? name = freezed,
-    Object? startTime = freezed,
+    Object? suiteId = null,
+    Object? name = null,
+    Object? startTime = null,
     Object? url = freezed,
     Object? rootUrl = freezed,
-    Object? endTime = freezed,
-    Object? hidden = freezed,
-    Object? skipped = freezed,
-    Object? problems = freezed,
-    Object? prints = freezed,
+    Object? endTime = null,
+    Object? hidden = null,
+    Object? skipped = null,
+    Object? problems = null,
+    Object? prints = null,
   }) {
     return _then(
-      _$_Test(
+      _$TestImpl(
         suiteId:
-            suiteId == freezed
+            null == suiteId
                 ? _value.suiteId
                 : suiteId // ignore: cast_nullable_to_non_nullable
                     as int,
         name:
-            name == freezed
+            null == name
                 ? _value.name
                 : name // ignore: cast_nullable_to_non_nullable
                     as String,
         startTime:
-            startTime == freezed
+            null == startTime
                 ? _value.startTime
                 : startTime // ignore: cast_nullable_to_non_nullable
                     as int,
         url:
-            url == freezed
+            freezed == url
                 ? _value.url
                 : url // ignore: cast_nullable_to_non_nullable
                     as String?,
         rootUrl:
-            rootUrl == freezed
+            freezed == rootUrl
                 ? _value.rootUrl
                 : rootUrl // ignore: cast_nullable_to_non_nullable
                     as String?,
         endTime:
-            endTime == freezed
+            null == endTime
                 ? _value.endTime
                 : endTime // ignore: cast_nullable_to_non_nullable
                     as int,
         hidden:
-            hidden == freezed
+            null == hidden
                 ? _value.hidden
                 : hidden // ignore: cast_nullable_to_non_nullable
                     as bool,
         skipped:
-            skipped == freezed
+            null == skipped
                 ? _value.skipped
                 : skipped // ignore: cast_nullable_to_non_nullable
                     as bool,
         problems:
-            problems == freezed
+            null == problems
                 ? _value._problems
                 : problems // ignore: cast_nullable_to_non_nullable
                     as List<Problem>,
         prints:
-            prints == freezed
+            null == prints
                 ? _value._prints
                 : prints // ignore: cast_nullable_to_non_nullable
                     as List<String>,
@@ -247,8 +264,8 @@ class __$$_TestCopyWithImpl<$Res> extends _$TestCopyWithImpl<$Res> implements _$
 
 /// @nodoc
 
-class _$_Test extends _Test {
-  _$_Test({
+class _$TestImpl extends _Test {
+  _$TestImpl({
     required this.suiteId,
     required this.name,
     required this.startTime,
@@ -308,6 +325,7 @@ class _$_Test extends _Test {
   /// A list of any problems that occured during this test.
   @override
   List<Problem> get problems {
+    if (_problems is EqualUnmodifiableListView) return _problems;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_problems);
   }
@@ -318,6 +336,7 @@ class _$_Test extends _Test {
   /// A list of any messages emitted during this test.
   @override
   List<String> get prints {
+    if (_prints is EqualUnmodifiableListView) return _prints;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_prints);
   }
@@ -328,18 +347,19 @@ class _$_Test extends _Test {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Test &&
-            const DeepCollectionEquality().equals(other.suiteId, suiteId) &&
-            const DeepCollectionEquality().equals(other.name, name) &&
-            const DeepCollectionEquality().equals(other.startTime, startTime) &&
-            const DeepCollectionEquality().equals(other.url, url) &&
-            const DeepCollectionEquality().equals(other.rootUrl, rootUrl) &&
-            const DeepCollectionEquality().equals(other.endTime, endTime) &&
-            const DeepCollectionEquality().equals(other.hidden, hidden) &&
-            const DeepCollectionEquality().equals(other.skipped, skipped) &&
+            other is _$TestImpl &&
+            (identical(other.suiteId, suiteId) || other.suiteId == suiteId) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.startTime, startTime) ||
+                other.startTime == startTime) &&
+            (identical(other.url, url) || other.url == url) &&
+            (identical(other.rootUrl, rootUrl) || other.rootUrl == rootUrl) &&
+            (identical(other.endTime, endTime) || other.endTime == endTime) &&
+            (identical(other.hidden, hidden) || other.hidden == hidden) &&
+            (identical(other.skipped, skipped) || other.skipped == skipped) &&
             const DeepCollectionEquality().equals(other._problems, _problems) &&
             const DeepCollectionEquality().equals(other._prints, _prints));
   }
@@ -347,21 +367,25 @@ class _$_Test extends _Test {
   @override
   int get hashCode => Object.hash(
     runtimeType,
-    const DeepCollectionEquality().hash(suiteId),
-    const DeepCollectionEquality().hash(name),
-    const DeepCollectionEquality().hash(startTime),
-    const DeepCollectionEquality().hash(url),
-    const DeepCollectionEquality().hash(rootUrl),
-    const DeepCollectionEquality().hash(endTime),
-    const DeepCollectionEquality().hash(hidden),
-    const DeepCollectionEquality().hash(skipped),
+    suiteId,
+    name,
+    startTime,
+    url,
+    rootUrl,
+    endTime,
+    hidden,
+    skipped,
     const DeepCollectionEquality().hash(_problems),
     const DeepCollectionEquality().hash(_prints),
   );
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Test
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  _$$_TestCopyWith<_$_Test> get copyWith => __$$_TestCopyWithImpl<_$_Test>(this, _$identity);
+  @pragma('vm:prefer-inline')
+  _$$TestImplCopyWith<_$TestImpl> get copyWith =>
+      __$$TestImplCopyWithImpl<_$TestImpl>(this, _$identity);
 }
 
 abstract class _Test extends Test {
@@ -376,44 +400,57 @@ abstract class _Test extends Test {
     final bool skipped,
     required final List<Problem> problems,
     required final List<String> prints,
-  }) = _$_Test;
+  }) = _$TestImpl;
   _Test._() : super._();
 
-  @override
   /// The id of the suite to which this test belongs.
+  @override
   int get suiteId;
-  @override
+
   /// The name of this test, including prefixes from any containing groups.
+  @override
   String get name;
-  @override
+
   /// The time (in milliseconds) that has elapsed between the test runner starting and this test starting.
+  @override
   int get startTime;
-  @override
+
   /// Optional URL for the file in which this test was defined
-  String? get url;
   @override
+  String? get url;
+
   /// Optional URL for the original test suite in which this test was defined
   ///
   /// Will only be present if different from `url`
-  String? get rootUrl;
   @override
+  String? get rootUrl;
+
   /// The time (in milliseconds) that has elapsed between the test runner starting and this test completing.
   ///
   /// This will be -1 if this test was not completed.
+  @override
   int get endTime;
-  @override
+
   /// Whether this test's result should be hidden.
+  @override
   bool get hidden;
-  @override
+
   /// Whether this test (or some part of it) was skipped.
+  @override
   bool get skipped;
-  @override
+
   /// A list of any problems that occured during this test.
+  @override
   List<Problem> get problems;
-  @override
+
   /// A list of any messages emitted during this test.
-  List<String> get prints;
   @override
-  @JsonKey(ignore: true)
-  _$$_TestCopyWith<_$_Test> get copyWith => throw _privateConstructorUsedError;
+  List<String> get prints;
+
+  /// Create a copy of Test
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$TestImplCopyWith<_$TestImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }

--- a/lib/src/processing/processors/processor_0_1.dart
+++ b/lib/src/processing/processors/processor_0_1.dart
@@ -1,4 +1,5 @@
-import 'package:better_test_reporter/json_reporter_protocol_0_1.dart' as json_reporter_protocol_0_1;
+import 'package:better_test_reporter/json_reporter_protocol_0_1.dart'
+    as json_reporter_protocol_0_1;
 import 'package:better_test_reporter/src/processing/models/models.dart';
 import 'package:better_test_reporter/src/processing/processors/processor.dart';
 
@@ -34,14 +35,27 @@ class Processor0_1 implements Processor {
           );
         },
         testDone: (time, result, testId, hidden, skipped) {
-          tests[testId] = tests[testId]!.copyWith(hidden: hidden, skipped: skipped, endTime: time);
+          tests[testId] = tests[testId]!.copyWith(
+            hidden: hidden,
+            skipped: skipped,
+            endTime: time,
+          );
         },
         suite: (time, suite) {
-          suites[suite.id] = Suite(path: suite.path, allTests: [], platform: suite.platform);
+          suites[suite.id] = Suite(
+            path: suite.path,
+            allTests: [],
+            platform: suite.platform,
+          );
         },
         error: (time, testId, error, stacktrace, isFailure) {
-          final problems = List<Problem>.from(tests[testId]!.problems)
-            ..add(Problem(message: error, stacktrace: stacktrace, isFailure: isFailure));
+          final problems = List<Problem>.from(tests[testId]!.problems)..add(
+            Problem(
+              message: error,
+              stacktrace: stacktrace,
+              isFailure: isFailure,
+            ),
+          );
           tests[testId] = tests[testId]!.copyWith(problems: problems);
         },
         print: (time, testId, messageType, message) {
@@ -52,7 +66,8 @@ class Processor0_1 implements Processor {
       );
     }
     for (final test in tests.values) {
-      final allTests = List<Test>.from(suites[test.suiteId]!.allTests)..add(test);
+      final allTests = List<Test>.from(suites[test.suiteId]!.allTests)
+        ..add(test);
       suites[test.suiteId] = suites[test.suiteId]!.copyWith(allTests: allTests);
     }
     return Report(suites: suites.values, timestamp: timestamp);

--- a/lib/src/processing/processors/processor_0_1.dart
+++ b/lib/src/processing/processors/processor_0_1.dart
@@ -1,5 +1,4 @@
-import 'package:better_test_reporter/json_reporter_protocol_0_1.dart'
-    as json_reporter_protocol_0_1;
+import 'package:better_test_reporter/json_reporter_protocol_0_1.dart' as json_reporter_protocol_0_1;
 import 'package:better_test_reporter/src/processing/models/models.dart';
 import 'package:better_test_reporter/src/processing/processors/processor.dart';
 
@@ -34,49 +33,18 @@ class Processor0_1 implements Processor {
             prints: [],
           );
         },
-        testDone: (
-          time,
-          result,
-          testId,
-          hidden,
-          skipped,
-        ) {
-          tests[testId] = tests[testId]!.copyWith(
-            hidden: hidden,
-            skipped: skipped,
-            endTime: time,
-          );
+        testDone: (time, result, testId, hidden, skipped) {
+          tests[testId] = tests[testId]!.copyWith(hidden: hidden, skipped: skipped, endTime: time);
         },
         suite: (time, suite) {
-          suites[suite.id] = Suite(
-            path: suite.path,
-            allTests: [],
-            platform: suite.platform,
-          );
+          suites[suite.id] = Suite(path: suite.path, allTests: [], platform: suite.platform);
         },
-        error: (
-          time,
-          testId,
-          error,
-          stacktrace,
-          isFailure,
-        ) {
+        error: (time, testId, error, stacktrace, isFailure) {
           final problems = List<Problem>.from(tests[testId]!.problems)
-            ..add(
-              Problem(
-                message: error,
-                stacktrace: stacktrace,
-                isFailure: isFailure,
-              ),
-            );
+            ..add(Problem(message: error, stacktrace: stacktrace, isFailure: isFailure));
           tests[testId] = tests[testId]!.copyWith(problems: problems);
         },
-        print: (
-          time,
-          testId,
-          messageType,
-          message,
-        ) {
+        print: (time, testId, messageType, message) {
           final prints = List<String>.from(tests[testId]!.prints)..add(message);
           tests[testId] = tests[testId]!.copyWith(prints: prints);
         },
@@ -84,8 +52,7 @@ class Processor0_1 implements Processor {
       );
     }
     for (final test in tests.values) {
-      final allTests = List<Test>.from(suites[test.suiteId]!.allTests)
-        ..add(test);
+      final allTests = List<Test>.from(suites[test.suiteId]!.allTests)..add(test);
       suites[test.suiteId] = suites[test.suiteId]!.copyWith(allTests: allTests);
     }
     return Report(suites: suites.values, timestamp: timestamp);

--- a/lib/src/processing/test_json_processor.dart
+++ b/lib/src/processing/test_json_processor.dart
@@ -22,7 +22,9 @@ class TestJsonProcessor {
     if (events.first['type'] != 'start') {
       throw UnsupportedError("First event was not a 'start' event");
     }
-    final processorDelegate = _createProcessorDelegate(protocolVersion: events.first['protocolVersion'] as String);
+    final processorDelegate = _createProcessorDelegate(
+      protocolVersion: events.first['protocolVersion'] as String,
+    );
     return processorDelegate.process(events);
   }
 

--- a/lib/src/processing/test_json_processor.dart
+++ b/lib/src/processing/test_json_processor.dart
@@ -22,9 +22,7 @@ class TestJsonProcessor {
     if (events.first['type'] != 'start') {
       throw UnsupportedError("First event was not a 'start' event");
     }
-    final processorDelegate = _createProcessorDelegate(
-      protocolVersion: events.first['protocolVersion'] as String,
-    );
+    final processorDelegate = _createProcessorDelegate(protocolVersion: events.first['protocolVersion'] as String);
     return processorDelegate.process(events);
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,505 +5,609 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      url: "https://pub.dartlang.org"
+      sha256: da0d9209ca76bde579f2da330aeb9df62b6319c834fa7baae052021b0462401f
+      url: "https://pub.dev"
     source: hosted
-    version: "47.0.0"
+    version: "85.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      url: "https://pub.dartlang.org"
+      sha256: "01949bf52ad33f0e0f74f881fbaac4f348c556531951d92c8d16f1262aa19ff8"
+      url: "https://pub.dev"
     source: hosted
-    version: "4.7.0"
+    version: "7.5.4"
   args:
     dependency: "direct main"
     description:
       name: args
-      url: "https://pub.dartlang.org"
+      sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04
+      url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.7.0"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   build:
     dependency: transitive
     description:
       name: build
-      url: "https://pub.dartlang.org"
+      sha256: "51dc711996cbf609b90cbe5b335bbce83143875a9d58e4b5c6d3c4f684d3dda7"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.5.4"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      url: "https://pub.dartlang.org"
+      sha256: "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.2"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      url: "https://pub.dartlang.org"
+      sha256: "8e928697a82be082206edb0b9c99c5a4ad6bc31c9e9b8b2f291ae65cd4a25daa"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "4.0.4"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      url: "https://pub.dartlang.org"
+      sha256: ee4257b3f20c0c90e72ed2b57ad637f694ccba48839a821e87db762548c22a62
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.9"
+    version: "2.5.4"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      url: "https://pub.dartlang.org"
+      sha256: "382a4d649addbfb7ba71a3631df0ec6a45d5ab9b098638144faf27f02778eb53"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.2.1"
+    version: "2.5.4"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      url: "https://pub.dartlang.org"
+      sha256: "85fbbb1036d576d966332a3f5ce83f2ce66a40bea1a94ad2d5fc29a19a0d3792"
+      url: "https://pub.dev"
     source: hosted
-    version: "7.2.4"
+    version: "9.1.2"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
-      url: "https://pub.dartlang.org"
+      sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
+      url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
   built_value:
     dependency: transitive
     description:
       name: built_value
-      url: "https://pub.dartlang.org"
+      sha256: "082001b5c3dc495d4a42f1d5789990505df20d8547d42507c29050af6933ee27"
+      url: "https://pub.dev"
     source: hosted
-    version: "8.4.1"
+    version: "8.10.1"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
-      url: "https://pub.dartlang.org"
+      sha256: feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.3"
+  cli_config:
+    dependency: transitive
+    description:
+      name: cli_config
+      sha256: ac20a183a07002b700f0c25e61b7ee46b23c309d76ab7b7640a028f18e4d99ec
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
-      url: "https://pub.dartlang.org"
+      sha256: "0ec10bf4a89e4c613960bf1e8b42c64127021740fb21640c29c909826a5eea3e"
+      url: "https://pub.dev"
     source: hosted
-    version: "4.2.0"
+    version: "4.10.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.19.1"
   convert:
     dependency: transitive
     description:
       name: convert
-      url: "https://pub.dartlang.org"
+      sha256: b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.1.2"
   coverage:
     dependency: transitive
     description:
       name: coverage
-      url: "https://pub.dartlang.org"
+      sha256: aa07dbe5f2294c827b7edb9a87bba44a9c15a3cc81bc8da2ca19b37322d30080
+      url: "https://pub.dev"
     source: hosted
-    version: "1.6.0"
+    version: "1.14.1"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://pub.dartlang.org"
+      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.6"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      url: "https://pub.dartlang.org"
+      sha256: "5b236382b47ee411741447c1f1e111459c941ea1b3f2b540dde54c210a3662af"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.2.3"
+    version: "3.1.0"
   file:
     dependency: transitive
     description:
       name: file
-      url: "https://pub.dartlang.org"
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      url: "https://pub.dev"
     source: hosted
-    version: "6.1.4"
+    version: "7.0.1"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
-      url: "https://pub.dartlang.org"
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.1"
   freezed:
     dependency: "direct dev"
     description:
       name: freezed
-      url: "https://pub.dartlang.org"
+      sha256: "59a584c24b3acdc5250bb856d0d3e9c0b798ed14a4af1ddb7dc1c7b41df91c9c"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0+1"
+    version: "2.5.8"
   freezed_annotation:
     dependency: "direct main"
     description:
       name: freezed_annotation
-      url: "https://pub.dartlang.org"
+      sha256: c2e2d632dd9b8a2b7751117abcfc2b4888ecfe181bd9fca7170d9ef02e595fe2
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.4.4"
   frontend_server_client:
     dependency: transitive
     description:
       name: frontend_server_client
-      url: "https://pub.dartlang.org"
+      sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "4.0.0"
   glob:
     dependency: transitive
     description:
       name: glob
-      url: "https://pub.dartlang.org"
+      sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.3"
   graphs:
     dependency: transitive
     description:
       name: graphs
-      url: "https://pub.dartlang.org"
+      sha256: "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.3.2"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: "2c11f3f94c687ee9bad77c171151672986360b2b001d109814ee7140b2cf261b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      url: "https://pub.dartlang.org"
+      sha256: aa6199f908078bb1c5efb8d8638d4ae191aac11b311132c3ef48ce352fb52ef8
+      url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "3.2.2"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      url: "https://pub.dartlang.org"
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
+      url: "https://pub.dev"
     source: hosted
-    version: "4.0.1"
+    version: "4.1.2"
   intl:
     dependency: "direct main"
     description:
       name: intl
-      url: "https://pub.dartlang.org"
+      sha256: "910f85bce16fb5c6f614e117efa303e85a1731bb0081edf3604a2ae6e9a3cc91"
+      url: "https://pub.dev"
     source: hosted
     version: "0.17.0"
   io:
     dependency: transitive
     description:
       name: io
-      url: "https://pub.dartlang.org"
+      sha256: dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.5"
   js:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.7.2"
   json_annotation:
     dependency: "direct main"
     description:
       name: json_annotation
-      url: "https://pub.dartlang.org"
+      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
+      url: "https://pub.dev"
     source: hosted
-    version: "4.6.0"
+    version: "4.9.0"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
-      url: "https://pub.dartlang.org"
+      sha256: c50ef5fc083d5b5e12eef489503ba3bf5ccc899e487d691584699b4bdefeea8c
+      url: "https://pub.dev"
     source: hosted
-    version: "6.3.2"
+    version: "6.9.5"
   lints:
     dependency: "direct dev"
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.1"
   logging:
     dependency: transitive
     description:
       name: logging
-      url: "https://pub.dartlang.org"
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.17"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      url: "https://pub.dartlang.org"
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "2.0.0"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
-      url: "https://pub.dartlang.org"
+      sha256: "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      url: "https://pub.dartlang.org"
+      sha256: f096c55ebb7deb7e384101542bfba8c52696c1b56fca2eb62827989ef2353bbc
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.1"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
-      url: "https://pub.dartlang.org"
+      sha256: "07c8f0b1913bcde1ff0d26e57ace2f3012ccbf2b204e070290dad3bb22797646"
+      url: "https://pub.dev"
     source: hosted
-    version: "5.0.0"
+    version: "6.1.0"
   pool:
     dependency: transitive
     description:
       name: pool
-      url: "https://pub.dartlang.org"
+      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
   pub_semver:
     dependency: "direct main"
     description:
       name: pub_semver
-      url: "https://pub.dartlang.org"
+      sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.2.0"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      url: "https://pub.dartlang.org"
+      sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.5.0"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      url: "https://pub.dartlang.org"
+      sha256: e7dd780a7ffb623c57850b33f43309312fc863fb6aa3d276a754bb299839ef12
+      url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.2"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
-      url: "https://pub.dartlang.org"
+      sha256: "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
-      url: "https://pub.dartlang.org"
+      sha256: c87c3875f91262785dade62d135760c2c69cb217ac759485334c5857ad89f6e3
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.3"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      url: "https://pub.dartlang.org"
+      sha256: "3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "3.0.0"
   source_gen:
     dependency: transitive
     description:
       name: source_gen
-      url: "https://pub.dartlang.org"
+      sha256: "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "2.0.0"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
-      url: "https://pub.dartlang.org"
+      sha256: "86d247119aedce8e63f4751bd9626fc9613255935558447569ad42f9f5b48b3c"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.5"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c0713a43e323c3302c2abe2a1cc89aa057a387101ebd280371d6a6c9fa68516b
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
-      url: "https://pub.dartlang.org"
+      sha256: "190222579a448b03896e0ca6eca5998fa810fda630c1d65e2f78b3f638f54812"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.10.10"
+    version: "0.10.13"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.4"
   stream_transform:
     dependency: transitive
     description:
       name: stream_transform
-      url: "https://pub.dartlang.org"
+      sha256: ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.4.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test:
     dependency: "direct dev"
     description:
       name: test
-      url: "https://pub.dartlang.org"
+      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.21.6"
+    version: "1.26.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.14"
+    version: "0.7.6"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      url: "https://pub.dartlang.org"
+      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.18"
+    version: "0.6.11"
   timing:
     dependency: transitive
     description:
       name: timing
-      url: "https://pub.dartlang.org"
+      sha256: "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.2"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
+      url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.4.0"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      url: "https://pub.dartlang.org"
+      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
+      url: "https://pub.dev"
     source: hosted
-    version: "9.4.0"
+    version: "15.0.2"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      url: "https://pub.dartlang.org"
+      sha256: "0b7fd4a0bbc4b92641dbf20adfd7e3fd1398fe17102d94b674234563e110088a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
+  web_socket:
+    dependency: transitive
+    description:
+      name: web_socket
+      sha256: "34d64019aa8e36bf9842ac014bb5d2f5586ca73df5e4d9bf5c936975cae6982c"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      url: "https://pub.dartlang.org"
+      sha256: d645757fb0f4773d602444000a8131ff5d48c9e47adfe9772652dd1a4f2d45c8
+      url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "3.0.3"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      url: "https://pub.dartlang.org"
+      sha256: "87d3f2333bb240704cd3f1c6b5b7acd8a10e7f0bc28c28dcf14e782014f4a572"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   xml:
     dependency: "direct main"
     description:
       name: xml
-      url: "https://pub.dartlang.org"
+      sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226
+      url: "https://pub.dev"
     source: hosted
-    version: "6.1.0"
+    version: "6.5.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      url: "https://pub.dartlang.org"
+      sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
+      url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.3"
 sdks:
-  dart: ">=2.18.1 <3.0.0"
+  dart: ">=3.7.2 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   args: ^2.3.1
   freezed_annotation: ^2.1.0
   intl: ^0.17.0
-  json_annotation: ^4.6.0
+  json_annotation: ^4.9.0
   pub_semver: ^2.1.1
   xml: ^6.1.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.1
 homepage: https://github.com/Betterment/better_test_reporter
 
 environment:
-  sdk: ">=2.18.1 <3.0.0"
+  sdk: ">=3.7.2 <4.0.0"
 
 dev_dependencies:
   build_runner: ^2.2.1
@@ -12,6 +12,7 @@ dev_dependencies:
   json_serializable: ^6.3.2
   lints: ^2.0.0
   test: ^1.21.6
+
 dependencies:
   args: ^2.3.1
   freezed_annotation: ^2.1.0

--- a/test/junit_xml/test_json_to_junit_test.dart
+++ b/test/junit_xml/test_json_to_junit_test.dart
@@ -54,16 +54,11 @@ void main() {
     });
 
     test('it generates a basic report xml', () {
-      final subject = TestJsonToJunit(
-        base: '',
-        package: '',
-      );
+      final subject = TestJsonToJunit(base: '', package: '');
 
       final xmlReport = subject.toXml(report);
 
-      expect(
-        xmlReport,
-        '''<?xml version="1.0" encoding="UTF-8"?>
+      expect(xmlReport, '''<?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
   <testsuite errors="0" failures="1" tests="2" skipped="0" name="test.some_file" timestamp="$formattedTimestamp">
     <properties>
@@ -76,21 +71,15 @@ void main() {
       <failure message="1 failure, see stacktrace for details">Failure: Expected false but was true</failure>
     </testcase>
   </testsuite>
-</testsuites>''',
-      );
+</testsuites>''');
     });
 
     test('it generates a report xml with proper package prefixes', () {
-      final subject = TestJsonToJunit(
-        base: '',
-        package: 'package',
-      );
+      final subject = TestJsonToJunit(base: '', package: 'package');
 
       final xmlReport = subject.toXml(report);
 
-      expect(
-        xmlReport,
-        '''<?xml version="1.0" encoding="UTF-8"?>
+      expect(xmlReport, '''<?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
   <testsuite errors="0" failures="1" tests="2" skipped="0" name="package.test.some_file" timestamp="$formattedTimestamp">
     <properties>
@@ -103,21 +92,15 @@ void main() {
       <failure message="1 failure, see stacktrace for details">Failure: Expected false but was true</failure>
     </testcase>
   </testsuite>
-</testsuites>''',
-      );
+</testsuites>''');
     });
 
     test('it generates a report xml with base prefix removed', () {
-      final subject = TestJsonToJunit(
-        base: 'test',
-        package: '',
-      );
+      final subject = TestJsonToJunit(base: 'test', package: '');
 
       final xmlReport = subject.toXml(report);
 
-      expect(
-        xmlReport,
-        '''<?xml version="1.0" encoding="UTF-8"?>
+      expect(xmlReport, '''<?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
   <testsuite errors="0" failures="1" tests="2" skipped="0" name="some_file" timestamp="$formattedTimestamp">
     <properties>
@@ -130,8 +113,7 @@ void main() {
       <failure message="1 failure, see stacktrace for details">Failure: Expected false but was true</failure>
     </testcase>
   </testsuite>
-</testsuites>''',
-      );
+</testsuites>''');
     });
   });
 
@@ -185,16 +167,11 @@ void main() {
     });
 
     test('it generates a basic report xml', () {
-      final subject = TestJsonToJunit(
-        base: '',
-        package: '',
-      );
+      final subject = TestJsonToJunit(base: '', package: '');
 
       final xmlReport = subject.toXml(report);
 
-      expect(
-        xmlReport,
-        '''<?xml version="1.0" encoding="UTF-8"?>
+      expect(xmlReport, '''<?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
   <testsuite errors="0" failures="1" tests="2" skipped="0" name=".Users.bilbo.src.repo.package.test.some_file" timestamp="$formattedTimestamp">
     <properties>
@@ -207,8 +184,7 @@ void main() {
       <failure message="1 failure, see stacktrace for details">Failure: Expected false but was true</failure>
     </testcase>
   </testsuite>
-</testsuites>''',
-      );
+</testsuites>''');
     });
 
     test('it generates a report xml with proper package prefixes', () {
@@ -219,9 +195,7 @@ void main() {
 
       final xmlReport = subject.toXml(report);
 
-      expect(
-        xmlReport,
-        '''<?xml version="1.0" encoding="UTF-8"?>
+      expect(xmlReport, '''<?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
   <testsuite errors="0" failures="1" tests="2" skipped="0" name="package.test.some_file" timestamp="$formattedTimestamp">
     <properties>
@@ -234,8 +208,7 @@ void main() {
       <failure message="1 failure, see stacktrace for details">Failure: Expected false but was true</failure>
     </testcase>
   </testsuite>
-</testsuites>''',
-      );
+</testsuites>''');
     });
 
     test('it generates a report xml with base prefix removed', () {
@@ -246,9 +219,7 @@ void main() {
 
       final xmlReport = subject.toXml(report);
 
-      expect(
-        xmlReport,
-        '''<?xml version="1.0" encoding="UTF-8"?>
+      expect(xmlReport, '''<?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
   <testsuite errors="0" failures="1" tests="2" skipped="0" name="test.some_file" timestamp="$formattedTimestamp">
     <properties>
@@ -261,8 +232,7 @@ void main() {
       <failure message="1 failure, see stacktrace for details">Failure: Expected false but was true</failure>
     </testcase>
   </testsuite>
-</testsuites>''',
-      );
+</testsuites>''');
     });
   });
 }

--- a/test/processing/processors/processor_0_1_test.dart
+++ b/test/processing/processors/processor_0_1_test.dart
@@ -11,11 +11,7 @@ void main() {
         'protocolVersion': '0.1.0',
         'pid': 1234,
       },
-      <String, dynamic>{
-        'type': 'allSuites',
-        'time': 15,
-        'count': 1,
-      },
+      <String, dynamic>{'type': 'allSuites', 'time': 15, 'count': 1},
       <String, dynamic>{
         'type': 'suite',
         'time': 20,
@@ -82,11 +78,7 @@ void main() {
         'hidden': false,
         'skipped': false,
       },
-      <String, dynamic>{
-        'type': 'done',
-        'time': 90,
-        'success': false,
-      },
+      <String, dynamic>{'type': 'done', 'time': 90, 'success': false},
     ];
     final timestamp = DateTime.now();
 

--- a/test/processing/test_json_processor_test.dart
+++ b/test/processing/test_json_processor_test.dart
@@ -25,15 +25,9 @@ void main() {
         test('it throws an unsupported error', () {
           final processor = TestJsonProcessor(timestamp: DateTime.now());
           expect(
-            () => processor.process(
-              [
-                <String, dynamic>{
-                  'type': 'done',
-                  'time': 2378,
-                  'success': true,
-                }
-              ],
-            ),
+            () => processor.process([
+              <String, dynamic>{'type': 'done', 'time': 2378, 'success': true},
+            ]),
             throwsA(
               isA<UnsupportedError>().having(
                 (error) => error.message,
@@ -51,20 +45,15 @@ void main() {
             final startTime = DateTime.now();
             final processor = TestJsonProcessor(timestamp: startTime);
             expect(
-              processor.process(
-                [
-                  <String, dynamic>{
-                    'type': 'start',
-                    'time': 234,
-                    'protocolVersion': '0.1.1',
-                    'pid': 129,
-                  }
-                ],
-              ),
-              Report(
-                suites: [],
-                timestamp: startTime,
-              ),
+              processor.process([
+                <String, dynamic>{
+                  'type': 'start',
+                  'time': 234,
+                  'protocolVersion': '0.1.1',
+                  'pid': 129,
+                },
+              ]),
+              Report(suites: [], timestamp: startTime),
             );
           });
         });
@@ -73,22 +62,21 @@ void main() {
           test('it throws unsupported error', () {
             final processor = TestJsonProcessor(timestamp: DateTime.now());
             expect(
-              () => processor.process(
-                [
-                  <String, dynamic>{
-                    'type': 'start',
-                    'time': 234,
-                    'protocolVersion': '3.1.4',
-                    'pid': 129,
-                  }
-                ],
-              ),
+              () => processor.process([
+                <String, dynamic>{
+                  'type': 'start',
+                  'time': 234,
+                  'protocolVersion': '3.1.4',
+                  'pid': 129,
+                },
+              ]),
               throwsA(
                 isA<UnsupportedError>().having(
-                    (error) => error.message,
-                    'message',
-                    "No suitable processor found for version '3.1.4'. "
-                        "Supported versions:\n'^0.1.0'"),
+                  (error) => error.message,
+                  'message',
+                  "No suitable processor found for version '3.1.4'. "
+                      "Supported versions:\n'^0.1.0'",
+                ),
               ),
             );
           });


### PR DESCRIPTION
This PR includes automated changes from running [frizbee](https://github.com/stacklok/frizbee) to pin Github Actions. For more information on what this actually means, take a look at [our documentation on UnpinnedActions](https://github.com/betterment/claws?tab=readme-ov-file#unpinnedactions). Because `frizbee` will be replacing tags with their corresponding commit hash, this change should fundamentally be a no-op. This change just makes our code more explicit about what we're using.

Note that because we're touching Github Workflow files in this PR, there is a chance that [Claws](https://github.com/betterment/claws), our GHA Static Analyzer, will find other issues in those files that were introduced before this PR was created. These findings will need to be addressed before this PR can be merged. 

The Claws documentation has a good list for how to remediate each type of finding, but for brevity, here are some of the commonly seen ones:

* RiskyTriggers: Fires when a workflow has workflow_dispatch or pull_request_target; remediate by leaving comments explaning why, and put an ignore statement ([example](https://github.com/Betterment/retail/blob/92e76923f4e5d51e8386301538e383883cd5eb57/.github/workflows/create_datadog_slo.yml#L2-L4))
* UnsafeCheckout: Fires when a workflow checks out user supplied code; remediate by leaving a comment explaining how the user supplied code is used and confirm it isn't executed ([example](https://github.com/Betterment/linda-test/blob/6cd5954c7c1d2bdb781239b6686b3a5dcbcd6fda/.github/workflows/claws_fork_friendly.yml#L50-L54))

For other findings and how to remediate them, check the [Claws docs!](https://github.com/betterment/claws?tab=readme-ov-file#built-in-rules)

