### PR TITLE
chore: Replace `/domain` & `/platform` in PR template with CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Betterment/better_test_reporter-maintainers

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,8 +5,3 @@
 ### 🧪 Testing done
 <!-- Feel free to delete this section if it doesn't apply -->
 > What testing was added to cover the functionality added in this PR
-
-### Reviewers
-<!-- This is used by us to signal to the correct people that your PR needs review -->
-/domain @Betterment/better_test_reporter-maintainers
-/platform @Betterment/better_test_reporter-maintainers


### PR DESCRIPTION
This removes `/domain` and `/platform` declarations from the PR template and replaces them with a default CODEOWNERS-driven review request.

/no-platform